### PR TITLE
Finalize JOSS readiness, compatibility modes, tests, benchma.rks, and packaging cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ tests/Full_Tests/OHspecial_transformed_iso_data1.parquet
 pytest_cache/
 .coverage
 htmlcov/
+
+# Legacy Octave autosave artifacts
+pca_f_autosave
+pca_f_autosave*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,8 @@
 # -----------------------------
 # Core source files (Python + C++)
 # -----------------------------
-recursive-include src *.py *.pyi *.cpp *.hpp *.h
+recursive-include src *.py *.pyi *.cpp
+include src/vbpca_py/py.typed
 
 # -----------------------------
 # Top-level metadata
@@ -18,6 +19,3 @@ include MANIFEST.in
 # -----------------------------
 # Include all lightweight tests
 recursive-include tests *.py
-
-# Exclude heavy/full tests from the sdist
-recursive-exclude tests/Full_Tests *

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 Variational Bayesian PCA (Illin and Raiko, 2010) with support for missing data, sparse masks, optional bias terms, and an orthogonal post-rotation to a PCA basis. The implementation follows the original MATLAB reference while adding Python-native APIs and fast C++ extensions for heavy routines.
 
+## Statement of need
+
+Missing values are common in scientific and industrial tabular datasets, but many PCA workflows either impute first (which can bias uncertainty estimates) or drop incomplete samples/features. VBPCApy provides a practical Variational Bayesian PCA implementation that models missingness directly, exposes uncertainty-aware outputs, and preserves compatibility with the legacy MATLAB full-rank PCA behavior.
+
+This package targets researchers and practitioners who need:
+- robust latent-factor modeling with incomplete observations,
+- explicit uncertainty terms (posterior covariances, marginal variances), and
+- a Python API suitable for reproducible pipelines while retaining a parity path to legacy workflows.
+
+## Scope and reference behavior
+
+VBPCApy implements the Illin & Raiko (2010) VB-PCA formulation with modern Python ergonomics. The default `compat_mode="strict_legacy"` preserves historical behavior; `compat_mode="modern"` is available for updated semantics in selected preprocessing/masking cases.
+
 ## Features
 - Variational Bayesian PCA on dense or sparse data with explicit missing-entry masks.
 - Optional bias (per-feature mean) estimation and rotation to a PCA-aligned solution.
@@ -123,6 +136,7 @@ x_recon = auto.inverse_transform(z_recon)
 - `probe`: pass probe data/masks to monitor held-out RMS during fitting.
 - `maxiters`, `tol`, `verbose`: convergence control and logging.
 - `rotation`: final orthogonal rotation to a PCA-aligned solution.
+- `compat_mode`: compatibility policy for sparse empty-row/column handling (`strict_legacy` default, `modern` available).
 
 ### Convergence and stopping
 Each fit (including every k tried in `select_n_components`) runs the PCA_FULL EM loop until one of these criteria triggers or `maxiters` is reached:
@@ -138,7 +152,7 @@ Notes:
 - All options are case-insensitive and passed through the `VBPCA` constructor (or forwarded by `select_n_components`).
 - Reference implementation lives in [src/vbpca_py/_pca_full.py](src/vbpca_py/_pca_full.py) and [src/vbpca_py/_converge.py](src/vbpca_py/_converge.py).
 
-### Public API surface
+### API
 All public APIs can be imported directly from `vbpca_py`:
 ```python
 from vbpca_py import (
@@ -213,6 +227,19 @@ Run tests with coverage:
 just test-cov
 ```
 
+Run performance benchmarks (excluded from default CI):
+```bash
+# full perf suite
+just bench
+
+# scaling-only suite
+just bench-scale
+
+# Python vs Octave compare suite
+just bench-octave
+```
+
+
 ### Full legacy parity test requirements
 `just test` runs the standard suite and may skip optional Octave-backed parity tests if Octave tooling is unavailable.
 
@@ -263,7 +290,7 @@ We are committed to providing a welcoming and inclusive environment. Please:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.edge 
 
 ## Citation
 

--- a/justfile
+++ b/justfile
@@ -32,6 +32,26 @@ test:
 test-cov:
 	pytest -q --cov=src/vbpca_py --cov-report=term-missing
 
+# Run performance benchmarks (excluded from default test/ci runs).
+bench:
+	pytest -q -m perf --benchmark-only --benchmark-sort=mean
+
+# Run only scaling benchmarks across increasing matrix sizes.
+bench-scale:
+	pytest -q -m perf --benchmark-only -k scaling --benchmark-sort=mean
+
+# Run Python vs Octave comparison benchmarks (Octave test auto-skips if unavailable).
+bench-octave:
+	pytest -q -m perf --benchmark-only -k compare_dense --benchmark-sort=mean
+
+# Save benchmark baselines per compat mode for later comparisons.
+bench-save:
+	pytest -q -m perf --benchmark-only --benchmark-save=compat
+
+# Compare current benchmarks with the latest saved baseline.
+bench-compare:
+	pytest -q -m perf --benchmark-only --benchmark-compare --benchmark-sort=mean
+
 # Ensure Octave + mkoctfile are installed for full legacy parity tests.
 check-octave:
 	command -v octave >/dev/null || (echo "Missing octave. Install Octave first." && exit 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "vbpca_py"
 version = "0.1.0"
 description = "Variational Bayesian PCA (Illin & Raiko 2010) with support for missing data and missing entries."
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "Shany", email = "shany215.sn@gmail.com" },
     { name = "Joshua Macdonald", email = "jmacdo16@jh.edu" },
@@ -31,7 +31,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -75,7 +74,11 @@ testpaths = ["tests"]
 addopts = """
     -ra
     --strict-markers
+    -m "not perf"
 """
+markers = [
+    "perf: performance benchmarks (run explicitly with -m perf)",
+]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 import pybind11
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 
 
 def get_pybind_include() -> str:
@@ -69,22 +69,5 @@ ext_modules = [
 ]
 
 setup(
-    name="vbpca_py",
-    version="0.1.0",
-    description=(
-        "Variational Bayesian PCA (Illin & Raiko 2010) with support for missing data "
-        "and missing entries."
-    ),
-    author="Shany Naim and Joshua Macdonald",
-    author_email="shany215.sn@gmail.com, jmacdo16@jh.edu",
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
     ext_modules=ext_modules,
-    install_requires=[
-        "numpy>=1.24",
-        "scipy>=1.10",
-    ],
-    python_requires=">=3.11",
-    zip_safe=False,
-    include_package_data=True,
 )

--- a/src/vbpca_py/_full_update.py
+++ b/src/vbpca_py/_full_update.py
@@ -205,6 +205,7 @@ def _prepare_data(
         x_data,
         x_probe,
         opts["init"],
+        compat_mode=str(opts.get("compat_mode", "strict_legacy")),
     )
     # Carry updated init option forward.
     opts["init"] = init_opt
@@ -249,6 +250,7 @@ def _build_masks_sparse(
 def _build_masks_dense(
     x_data: Matrix,
     x_probe: Matrix | None,
+    compat_mode: str,
 ) -> tuple[Matrix, Matrix | None, Matrix, Matrix | None]:
     """Build masks and normalized data for dense inputs.
 
@@ -258,8 +260,11 @@ def _build_masks_dense(
     x_arr = np.asarray(x_data, dtype=float)
     mask = ~np.isnan(x_arr)
 
+    mode = compat_mode.strip().lower()
+    use_eps_for_zeros = mode == "strict_legacy"
     eps = np.finfo(float).eps
-    x_arr[x_arr == 0.0] = eps
+    if use_eps_for_zeros:
+        x_arr[x_arr == 0.0] = eps
     x_arr[np.isnan(x_arr)] = 0.0
     x_data = x_arr
 
@@ -267,7 +272,8 @@ def _build_masks_dense(
         x_probe_arr = np.asarray(x_probe, dtype=float)
         x_probe = x_probe_arr
         mask_probe = ~np.isnan(x_probe_arr)
-        x_probe_arr[x_probe_arr == 0.0] = eps
+        if use_eps_for_zeros:
+            x_probe_arr[x_probe_arr == 0.0] = eps
         x_probe_arr[np.isnan(x_probe_arr)] = 0.0
     else:
         mask_probe = None
@@ -288,7 +294,11 @@ def _build_masks_and_counts(
     if sp.issparse(x_data):
         x_data, x_probe, mask, mask_probe = _build_masks_sparse(x_data, x_probe)
     else:
-        x_data, x_probe, mask, mask_probe = _build_masks_dense(x_data, x_probe)
+        x_data, x_probe, mask, mask_probe = _build_masks_dense(
+            x_data,
+            x_probe,
+            str(opts.get("compat_mode", "strict_legacy")),
+        )
 
     if sp.issparse(mask):
         n_obs_row = np.array(mask.sum(axis=1)).ravel()
@@ -330,6 +340,27 @@ def _observed_indices(x_data: Matrix) -> tuple[np.ndarray, np.ndarray]:
     return np.asarray(i_idx_dense, dtype=np.intp), np.asarray(
         j_idx_dense, dtype=np.intp
     )
+
+
+def _observed_indices_with_mode(
+    x_data: Matrix,
+    mask: Matrix,
+    compat_mode: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return observed indices according to compatibility mode.
+
+    In ``strict_legacy`` mode this matches historical nonzero semantics.
+    In ``modern`` mode for dense inputs this uses the explicit observation
+    mask, decoupling observedness from numeric normalization conventions.
+    """
+    mode = compat_mode.strip().lower()
+    if mode == "modern" and not sp.issparse(x_data):
+        mask_arr = np.asarray(mask, dtype=bool)
+        i_idx_dense, j_idx_dense = np.nonzero(mask_arr)
+        return np.asarray(i_idx_dense, dtype=np.intp), np.asarray(
+            j_idx_dense, dtype=np.intp
+        )
+    return _observed_indices(x_data)
 
 
 def _missing_patterns_info(

--- a/src/vbpca_py/_pca_full.py
+++ b/src/vbpca_py/_pca_full.py
@@ -39,7 +39,7 @@ from ._full_update import (
     _final_rotation,
     _initialize_parameters,
     _missing_patterns_info,
-    _observed_indices,
+    _observed_indices_with_mode,
     _prepare_data,
     _recompute_rms,
     _update_bias,
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 Array = np.ndarray
 Sparse = sp.csr_matrix
 Matrix = Array | Sparse
+_ALLOWED_COMPAT_MODES = {"strict_legacy", "modern"}
 
 
 def _coerce_int(
@@ -243,7 +244,11 @@ def _prepare_problem(x: Matrix, opts: MutableMapping[str, object]) -> PreparedPr
     x_data, x_probe, mask, mask_probe, n_obs_row, n_data, n_probe = (
         _build_masks_and_counts(x_data, x_probe, opts)
     )
-    ix_obs, jx_obs = _observed_indices(x_data)
+    ix_obs, jx_obs = _observed_indices_with_mode(
+        x_data,
+        mask,
+        str(opts.get("compat_mode", "strict_legacy")),
+    )
 
     pattern_info = _missing_patterns_info(mask, opts, n_samples=x_data.shape[1])
 
@@ -918,6 +923,10 @@ def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
 
     Returns:
         Options dictionary after applying defaults and user overrides.
+
+    Raises:
+        ValueError: If ``compat_mode`` is not one of
+            ``{"strict_legacy", "modern"}``.
     """
     opts_default: dict[str, object] = {
         "init": "random",
@@ -936,9 +945,21 @@ def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
         "xprobe": None,
         "rotate2pca": 1,
         "display": 0,
+        "compat_mode": "strict_legacy",
     }
 
     opts, wrnmsg = _options(opts_default, **kwargs)
+
+    compat_mode_raw = opts.get("compat_mode", "strict_legacy")
+    compat_mode = str(compat_mode_raw).strip().lower()
+    if compat_mode not in _ALLOWED_COMPAT_MODES:
+        msg = (
+            "compat_mode must be one of {'strict_legacy', 'modern'} "
+            f"(got {compat_mode_raw!r})."
+        )
+        raise ValueError(msg)
+    opts["compat_mode"] = compat_mode
+
     if wrnmsg:
         logger.warning("pca_full options warning: %s", wrnmsg)
     return opts

--- a/src/vbpca_py/_remove_empty.py
+++ b/src/vbpca_py/_remove_empty.py
@@ -31,7 +31,10 @@ Matrix = Dense | Sparse
 # --------------------------------------------------------------------------- #
 # Internal helpers
 # --------------------------------------------------------------------------- #
-def _nonempty_indices(x: Matrix) -> tuple[np.ndarray, np.ndarray]:
+def _nonempty_indices(
+    x: Matrix,
+    compat_mode: str,
+) -> tuple[np.ndarray, np.ndarray]:
     """Return indices of non-empty rows and columns.
 
     For dense ``x``, emptiness means all-NaN.
@@ -43,8 +46,14 @@ def _nonempty_indices(x: Matrix) -> tuple[np.ndarray, np.ndarray]:
     """
     if sp.isspmatrix(x):
         x_csr = sp.csr_matrix(x)
-        col_sums = np.asarray(x_csr.sum(axis=0)).ravel()
-        row_sums = np.asarray(x_csr.sum(axis=1)).ravel()
+        if compat_mode == "modern":
+            abs_sums = x_csr.copy()
+            abs_sums.data = np.abs(abs_sums.data)
+            col_sums = np.asarray(abs_sums.sum(axis=0)).ravel()
+            row_sums = np.asarray(abs_sums.sum(axis=1)).ravel()
+        else:
+            col_sums = np.asarray(x_csr.sum(axis=0)).ravel()
+            row_sums = np.asarray(x_csr.sum(axis=1)).ravel()
         ic = np.where(col_sums != 0)[0]
         ir = np.where(row_sums != 0)[0]
     else:
@@ -159,6 +168,8 @@ def remove_empty_entries(
     x: Matrix,
     x_probe: Matrix | None,
     init: InitType,
+    *,
+    compat_mode: str = "strict_legacy",
 ) -> tuple[Matrix, Matrix | None, np.ndarray, np.ndarray, InitType]:
     """Remove rows and columns that are entirely empty and update ``init``.
 
@@ -172,6 +183,10 @@ def remove_empty_entries(
             keys ``"A"``, ``"Av"``, ``"S"``, and ``"Sv"`` are sliced
             consistently with the retained rows and columns. Non-dict
             values are passed through unchanged.
+        compat_mode:
+            Compatibility mode for sparse empty-row/column handling.
+            ``"strict_legacy"`` preserves sum-based legacy behavior;
+            ``"modern"`` uses absolute sums.
 
     Returns:
         A tuple ``(x_out, x_probe_out, ir, ic, init_out)`` where matrices
@@ -179,12 +194,19 @@ def remove_empty_entries(
         columns.
 
     Raises:
+        ValueError: If ``compat_mode`` is not one of
+            ``{"strict_legacy", "modern"}``.
         RuntimeError: If slicing yields ``None`` for non-null input.
     """
+    mode = compat_mode.strip().lower()
+    if mode not in {"strict_legacy", "modern"}:
+        msg = "compat_mode must be one of {'strict_legacy', 'modern'}."
+        raise ValueError(msg)
+
     n_rows_orig, n_cols_orig = x.shape
 
     # Identify kept rows/columns
-    ir, ic = _nonempty_indices(x)
+    ir, ic = _nonempty_indices(x, mode)
 
     # Fast path: nothing to remove
     if ir.size == n_rows_orig and ic.size == n_cols_orig:

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -286,3 +286,37 @@ def test_earlystop_has_priority_over_rms_and_cost() -> None:
 
     msg = convergence_check(opts, lc, angle_a=1.0, sd_iter=None)
     assert "early" in msg.lower()
+
+
+def test_rms_plateau_message_contains_window_info() -> None:
+    opts = {
+        "minangle": 0.0,
+        "earlystop": False,
+        "rmsstop": [2, 1e-3, 1e-3],
+        "cfstop": None,
+    }
+    lc = _lc(
+        rms=[0.5, 0.4, 0.4001, 0.4002],
+        prms=[1.0, 0.9, 0.8, 0.8],
+        cost=[10.0, 9.0, 8.5, 8.4],
+    )
+    msg = convergence_check(opts, lc, angle_a=1.0, sd_iter=None)
+    assert "RMS" in msg
+    assert "over 2 iterations" in msg
+
+
+def test_cost_plateau_message_contains_window_info() -> None:
+    opts = {
+        "minangle": 0.0,
+        "earlystop": False,
+        "rmsstop": None,
+        "cfstop": [2, 1e-3, 1e-3],
+    }
+    lc = _lc(
+        rms=[0.5, 0.4, 0.3, 0.2],
+        prms=[1.0, 0.9, 0.8, 0.7],
+        cost=[8.0, 7.0, 7.0004, 7.0006],
+    )
+    msg = convergence_check(opts, lc, angle_a=1.0, sd_iter=None)
+    assert "cost" in msg
+    assert "over 2 iterations" in msg

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1291,3 +1291,57 @@ def test_cost_regression_sparse_cf_full_octave_optional(
     np.testing.assert_allclose(cost_py_a, cost_a_oc, rtol=1e-10, atol=1e-10)
     np.testing.assert_allclose(cost_py_mu, cost_mu_oc, rtol=1e-10, atol=1e-10)
     np.testing.assert_allclose(cost_py_s, cost_s_oc, rtol=1e-10, atol=1e-10)
+
+
+def test_cost_mask_dtype_equivalence_dense() -> None:
+    rng = np.random.default_rng(1337)
+    x = rng.standard_normal((4, 5))
+    a = rng.standard_normal((4, 2))
+    s = rng.standard_normal((2, 5))
+    mu = rng.standard_normal(4)
+
+    mask_bool = (rng.random((4, 5)) > 0.2).astype(bool)
+    mask_int = mask_bool.astype(int)
+    mask_float = mask_bool.astype(float)
+
+    p_bool = CostParams(mu=mu, noise_variance=1.0, mask=mask_bool)
+    p_int = CostParams(mu=mu, noise_variance=1.0, mask=mask_int)
+    p_float = CostParams(mu=mu, noise_variance=1.0, mask=mask_float)
+
+    c_bool = compute_full_cost(x, a, s, p_bool)
+    c_int = compute_full_cost(x, a, s, p_int)
+    c_float = compute_full_cost(x, a, s, p_float)
+
+    np.testing.assert_allclose(c_bool, c_int, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(c_bool, c_float, rtol=1e-12, atol=1e-12)
+
+
+def test_cost_mu_prior_variance_zero_with_mu_variances_raises() -> None:
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    a = np.eye(2)
+    s = np.eye(2)
+    params = CostParams(
+        mu=np.array([0.2, -0.1]),
+        noise_variance=1.0,
+        mask=np.ones_like(x),
+        loading_priors=np.array([1.0, 1.0]),
+        mu_variances=np.array([0.1, 0.2]),
+        mu_prior_variance=0.0,
+    )
+    with pytest.raises(ValueError, match="mu_prior_variance"):
+        compute_full_cost(x, a, s, params)
+
+
+def test_cost_raises_when_n_data_non_positive_with_sxv() -> None:
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    a = np.eye(2)
+    s = np.eye(2)
+    params = CostParams(
+        mu=np.zeros(2),
+        noise_variance=1.0,
+        mask=np.ones_like(x),
+        s_xv=1.0,
+        n_data=0,
+    )
+    with pytest.raises(ValueError, match="n_data must be positive"):
+        compute_full_cost(x, a, s, params)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,6 +1,9 @@
 """Tests for the VBPCA estimator wrapper."""
 
+import pickle
+
 import numpy as np
+import pytest
 
 from vbpca_py.estimators import VBPCA
 
@@ -29,3 +32,104 @@ def test_vbpca_with_mask() -> None:
     assert model.scores_.shape[1] == x.shape[1]
     recon = model.inverse_transform()
     assert recon.shape == x.shape
+
+
+def test_transform_before_fit_raises() -> None:
+    model = VBPCA(n_components=2)
+    with pytest.raises(RuntimeError, match="Model not fitted"):
+        model.transform()
+
+
+def test_inverse_transform_before_fit_raises() -> None:
+    model = VBPCA(n_components=2)
+    with pytest.raises(RuntimeError, match="Model not fitted"):
+        model.inverse_transform()
+
+
+def test_transform_new_data_not_supported_raises() -> None:
+    rng = np.random.default_rng(11)
+    x = rng.standard_normal((5, 6))
+    model = VBPCA(n_components=2, maxiters=5)
+    model.fit(x)
+    with pytest.raises(NotImplementedError, match="not supported yet"):
+        model.transform(x)
+
+
+def test_fit_transform_deterministic_with_explicit_init() -> None:
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((5, 8))
+    init = {
+        "A": np.array(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [0.5, -0.25],
+                [0.2, 0.7],
+            ],
+            dtype=float,
+        ),
+        "S": rng.standard_normal((2, 8)),
+        "Mu": np.zeros((5, 1), dtype=float),
+        "V": 1.0,
+    }
+
+    init2 = {
+        "A": init["A"].copy(),
+        "S": init["S"].copy(),
+        "Mu": init["Mu"].copy(),
+        "V": float(init["V"]),
+    }
+
+    model1 = VBPCA(n_components=2, maxiters=5, init=init, rotate2pca=0, verbose=0)
+    model2 = VBPCA(
+        n_components=2,
+        maxiters=5,
+        init=init2,
+        rotate2pca=0,
+        verbose=0,
+    )
+
+    z1 = model1.fit_transform(x)
+    z2 = model2.fit_transform(x)
+
+    np.testing.assert_allclose(z1, z2, rtol=1e-10, atol=1e-12)
+    np.testing.assert_allclose(
+        model1.inverse_transform(), model2.inverse_transform(), rtol=1e-10, atol=1e-10
+    )
+
+
+def test_vbpca_pickle_roundtrip_preserves_predictions() -> None:
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((6, 9))
+
+    model = VBPCA(n_components=3, maxiters=6, verbose=0)
+    model.fit(x)
+    recon_before = model.inverse_transform()
+
+    blob = pickle.dumps(model)
+    model_loaded = pickle.loads(blob)
+    recon_after = model_loaded.inverse_transform()
+
+    np.testing.assert_allclose(recon_before, recon_after, rtol=1e-12, atol=1e-12)
+
+
+def test_get_options_includes_default_compat_mode() -> None:
+    """Resolved options should expose strict_legacy as default compat mode."""
+    model = VBPCA(n_components=2)
+    opts = model.get_options()
+    assert opts["compat_mode"] == "strict_legacy"
+
+
+def test_get_options_normalizes_compat_mode_case() -> None:
+    """compat_mode should be normalized case-insensitively."""
+    model = VBPCA(n_components=2, compat_mode=" MODERN ")
+    opts = model.get_options()
+    assert opts["compat_mode"] == "modern"
+
+
+def test_get_options_rejects_invalid_compat_mode() -> None:
+    """Invalid compat_mode values should raise at options resolution time."""
+    model = VBPCA(n_components=2, compat_mode="legacy")
+    with pytest.raises(ValueError, match="compat_mode"):
+        _ = model.get_options()

--- a/tests/test_full_update.py
+++ b/tests/test_full_update.py
@@ -12,12 +12,13 @@ Important diagnostic note
 -------------------------
 The dense-data path normalizes data by:
 - mask = ~isnan(x)
-- replacing exact zeros with eps
+- replacing exact zeros with eps in strict_legacy mode
 - replacing NaNs with 0
 
 That means "observed entries" must be defined consistently via the mask,
-NOT via np.nonzero(x_data) after normalization. Several tests below are
-explicitly designed to catch any accidental reliance on nonzeros.
+NOT via np.nonzero(x_data) after normalization. Modern mode enforces this
+directly; strict_legacy retains historical nonzero semantics. Several tests
+below are designed to catch accidental behavior drift.
 """
 
 from __future__ import annotations
@@ -48,6 +49,7 @@ from vbpca_py._full_update import (
     _loadings_update_general,
     _missing_patterns_info,
     _observed_indices,
+    _observed_indices_with_mode,
     _prepare_data,
     _recompute_rms,
     _score_update_fast_dense_no_av,
@@ -155,6 +157,88 @@ def test_build_masks_sparse_basic() -> None:
     assert n_data == float(mask.count_nonzero())
 
 
+def test_prepare_data_forwards_compat_mode_for_sparse_empty_detection() -> None:
+    """_prepare_data should honor compat_mode when pruning sparse rows/cols."""
+    x_sparse = sp.csr_matrix(np.array([[-1.0, 1.0], [0.0, 0.0]], dtype=float))
+
+    opts_strict: dict[str, object] = {
+        "xprobe": None,
+        "earlystop": 0,
+        "init": "random",
+        "verbose": 0,
+        "compat_mode": "strict_legacy",
+    }
+    x_strict, _, _, _, ir_strict, ic_strict = _prepare_data(x_sparse, opts_strict)
+
+    opts_modern: dict[str, object] = {
+        "xprobe": None,
+        "earlystop": 0,
+        "init": "random",
+        "verbose": 0,
+        "compat_mode": "modern",
+    }
+    x_modern, _, _, _, ir_modern, ic_modern = _prepare_data(x_sparse, opts_modern)
+
+    assert x_strict.shape == (0, 2)
+    assert np.array_equal(ir_strict, np.array([], dtype=int))
+    assert np.array_equal(ic_strict, np.array([0, 1]))
+
+    assert x_modern.shape == (1, 2)
+    assert np.array_equal(ir_modern, np.array([0]))
+    assert np.array_equal(ic_modern, np.array([0, 1]))
+
+
+def test_build_masks_dense_strict_legacy_rewrites_observed_zeros_to_eps() -> None:
+    """strict_legacy keeps historical eps substitution for observed zeros."""
+    x = np.array([[0.0, np.nan], [2.0, 0.0]], dtype=float)
+    opts: dict[str, object] = {
+        "xprobe": None,
+        "earlystop": 0,
+        "init": "random",
+        "verbose": 0,
+        "compat_mode": "strict_legacy",
+    }
+
+    x_data, x_probe, *_ = _prepare_data(x, opts)
+    x_norm, _x_probe2, mask, _mask_probe, _n_obs_row, _n_data, _n_probe = (
+        _build_masks_and_counts(x_data, x_probe, opts)
+    )
+
+    x_arr = np.asarray(x_norm, dtype=float)
+    mask_arr = np.asarray(mask, dtype=bool)
+    eps = np.finfo(float).eps
+
+    assert x_arr[0, 0] == eps
+    assert x_arr[1, 1] == eps
+    assert x_arr[0, 1] == 0.0
+    assert np.array_equal(mask_arr, np.array([[True, False], [True, True]]))
+
+
+def test_build_masks_dense_modern_keeps_observed_zeros_exact() -> None:
+    """modern mode should keep observed zeros as zero in dense preprocessing."""
+    x = np.array([[0.0, np.nan], [2.0, 0.0]], dtype=float)
+    opts: dict[str, object] = {
+        "xprobe": None,
+        "earlystop": 0,
+        "init": "random",
+        "verbose": 0,
+        "compat_mode": "modern",
+    }
+
+    x_data, x_probe, *_ = _prepare_data(x, opts)
+    x_norm, _x_probe2, mask, _mask_probe, _n_obs_row, _n_data, _n_probe = (
+        _build_masks_and_counts(x_data, x_probe, opts)
+    )
+
+    x_arr = np.asarray(x_norm, dtype=float)
+    mask_arr = np.asarray(mask, dtype=bool)
+
+    assert x_arr[0, 0] == 0.0
+    assert x_arr[1, 1] == 0.0
+    assert x_arr[0, 1] == 0.0
+    assert np.array_equal(mask_arr, np.array([[True, False], [True, True]]))
+
+
 def test_observed_indices_match_nonzero_dense_raw() -> None:
     """_observed_indices should match np.nonzero for dense input (raw semantics)."""
     x = np.array([[0.0, 1.0], [2.0, 0.0]])
@@ -163,6 +247,28 @@ def test_observed_indices_match_nonzero_dense_raw() -> None:
     exp_i, exp_j = np.nonzero(x)
     assert_allclose(ix, exp_i)
     assert_allclose(jx, exp_j)
+
+
+def test_observed_indices_with_mode_modern_uses_mask_dense() -> None:
+    """modern mode should use mask-defined observed entries for dense inputs."""
+    x = np.array([[0.0, 0.0], [5.0, 0.0]], dtype=float)
+    mask = np.array([[True, True], [True, False]], dtype=bool)
+
+    ix, jx = _observed_indices_with_mode(x, mask, "modern")
+    observed = _set_of_pairs(ix, jx)
+
+    assert observed == {(0, 0), (0, 1), (1, 0)}
+
+
+def test_observed_indices_with_mode_strict_matches_nonzero_dense() -> None:
+    """strict_legacy mode should preserve nonzero-based dense semantics."""
+    x = np.array([[0.0, 0.0], [5.0, 0.0]], dtype=float)
+    mask = np.array([[True, True], [True, False]], dtype=bool)
+
+    ix, jx = _observed_indices_with_mode(x, mask, "strict_legacy")
+    observed = _set_of_pairs(ix, jx)
+
+    assert observed == {(1, 0)}
 
 
 def test_missing_patterns_info_uniquesv_false() -> None:

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from vbpca_py.model_selection import SelectionConfig, select_n_components
 
@@ -73,3 +74,61 @@ def test_select_n_components_falls_back_when_prms_missing() -> None:
     assert best_k in (1, 2)
     assert np.isfinite(best_metrics["rms"]) or np.isfinite(best_metrics["prms"])
     assert len(trace) == 2
+
+
+def test_select_n_components_rejects_invalid_metric() -> None:
+    rng = np.random.default_rng(3)
+    x = _low_rank_data(rng, n_features=4, n_samples=6, rank=1)
+
+    cfg = SelectionConfig(metric="rms")
+    cfg.metric = "bad"  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="metric must be one of"):
+        select_n_components(x, config=cfg)
+
+
+def test_select_n_components_normalizes_component_candidates() -> None:
+    rng = np.random.default_rng(4)
+    x = _low_rank_data(rng, n_features=5, n_samples=7, rank=2)
+
+    best_k, _, trace, _ = select_n_components(
+        x,
+        components=[0, -1, 2, 2, 1],
+        config=SelectionConfig(metric="rms", compute_explained_variance=False),
+        maxiters=30,
+        verbose=0,
+    )
+
+    # _normalize_components keeps only unique positive values in input order.
+    assert [entry["k"] for entry in trace] == [2, 1]
+    assert best_k in (1, 2)
+
+
+def test_select_n_components_empty_after_normalization_raises() -> None:
+    rng = np.random.default_rng(5)
+    x = _low_rank_data(rng, n_features=4, n_samples=5, rank=1)
+
+    with pytest.raises(ValueError, match="at least one positive integer"):
+        select_n_components(x, components=[0, -2, -3])
+
+
+def test_select_n_components_patience_stops_early() -> None:
+    rng = np.random.default_rng(6)
+    x = _low_rank_data(rng, n_features=6, n_samples=10, rank=1)
+
+    cfg = SelectionConfig(
+        metric="rms",
+        patience=0,
+        max_trials=None,
+        compute_explained_variance=False,
+    )
+
+    _, _, trace, _ = select_n_components(
+        x,
+        components=[1, 2, 3, 4],
+        config=cfg,
+        maxiters=20,
+        verbose=0,
+    )
+
+    assert 1 <= len(trace) <= 4

--- a/tests/test_pca_full.py
+++ b/tests/test_pca_full.py
@@ -14,13 +14,13 @@ These tests cover:
 
 Notes on RMS consistency:
 -------------------------
-The implementation normalizes dense inputs by:
+In strict_legacy mode, the implementation normalizes dense inputs by:
 - treating NaNs as missing (mask = ~np.isnan(x)),
 - setting NaNs to 0.0 in the internal centered matrix, and
 - replacing exact zeros with eps to avoid ambiguity with sparse "missing" zeros.
 
-The helper `_compute_masked_rms_dense_like_impl` mirrors that behavior so that
-explicit RMS comparisons match lc["rms"].
+The helper `_compute_masked_rms_dense_like_impl` mirrors strict_legacy behavior
+so explicit RMS comparisons match lc["rms"] in those tests.
 """
 
 from __future__ import annotations
@@ -206,6 +206,21 @@ def test_pca_full_sparse_map_basic() -> None:
     # Va and Vmu should be finite (priors enabled in MAP)
     assert np.all(np.isfinite(va))
     assert np.isfinite(vmu)
+
+
+def test_pca_full_invalid_compat_mode_raises() -> None:
+    """pca_full should reject unsupported compatibility modes."""
+    x = _make_toy_dense_with_nans(n_features=4, n_samples=5, seed=17)
+    with pytest.raises(ValueError, match="compat_mode"):
+        _ = pca_full(
+            x,
+            n_components=2,
+            maxiters=2,
+            autosave=0,
+            display=0,
+            verbose=0,
+            compat_mode="legacy",
+        )
 
 
 # ----------------------------------------------------------------------
@@ -406,6 +421,128 @@ def test_pca_full_tiny_problem_smoke() -> None:
     assert all(np.isfinite(r) for r in result["lc"]["rms"] if not np.isnan(r))
 
 
+def test_pca_full_respects_maxiters_cap() -> None:
+    rng = np.random.default_rng(1234)
+    x = rng.standard_normal((6, 8))
+    result = pca_full(
+        x,
+        n_components=2,
+        maxiters=2,
+        algorithm="vb",
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    assert len(result["lc"]["rms"]) <= 3
+
+
+def test_pca_full_earlystop_with_no_probe_is_safe() -> None:
+    rng = np.random.default_rng(202)
+    x = rng.standard_normal((5, 7))
+    result = pca_full(
+        x,
+        n_components=2,
+        maxiters=6,
+        earlystop=1,
+        algorithm="vb",
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    assert len(result["lc"]["rms"]) >= 1
+    assert np.all(np.isnan(np.asarray(result["lc"]["prms"], dtype=float)))
+
+
+def test_pca_full_rmsstop_and_cfstop_both_provided() -> None:
+    rng = np.random.default_rng(555)
+    x = rng.standard_normal((5, 9))
+    result = pca_full(
+        x,
+        n_components=2,
+        maxiters=8,
+        rmsstop=np.array([2, 1e-8, 1e-8]),
+        cfstop=np.array([2, 1e-8, 1e-8]),
+        algorithm="vb",
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    rms = np.asarray(result["lc"]["rms"], dtype=float)
+    cost = np.asarray(result["lc"]["cost"], dtype=float)
+    assert rms.size >= 1
+    assert rms.size == cost.size
+    assert np.isfinite(cost).any()
+
+
+def test_pca_full_uniquesv_equivalence_when_fully_observed() -> None:
+    rng = np.random.default_rng(808)
+    x = rng.standard_normal((5, 7))
+    init = {
+        "A": rng.standard_normal((5, 2)),
+        "S": rng.standard_normal((2, 7)),
+        "Mu": np.zeros((5, 1), dtype=float),
+        "V": 1.0,
+    }
+
+    out_no = pca_full(
+        x,
+        n_components=2,
+        maxiters=4,
+        uniquesv=0,
+        init=init,
+        rotate2pca=0,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    out_yes = pca_full(
+        x,
+        n_components=2,
+        maxiters=4,
+        uniquesv=1,
+        init=init,
+        rotate2pca=0,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+
+    rms_no = float(np.asarray(out_no["lc"]["rms"], dtype=float)[-1])
+    rms_yes = float(np.asarray(out_yes["lc"]["rms"], dtype=float)[-1])
+
+    assert np.isfinite(rms_no)
+    assert np.isfinite(rms_yes)
+    assert abs(rms_no - rms_yes) < 0.5
+
+
+def test_pca_full_bias_toggle_mean_shift_effect() -> None:
+    rng = np.random.default_rng(1200)
+    x = rng.standard_normal((4, 10)) + 3.0  # strong global shift
+
+    out_bias = pca_full(
+        x,
+        n_components=2,
+        maxiters=5,
+        bias=1,
+        rotate2pca=0,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    out_nobias = pca_full(
+        x,
+        n_components=2,
+        maxiters=5,
+        bias=0,
+        rotate2pca=0,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+
+    assert np.linalg.norm(out_bias["Mu"]) > np.linalg.norm(out_nobias["Mu"])
+
+
 # ----------------------------------------------------------------------
 # Optional MATLAB regression tests
 # ----------------------------------------------------------------------
@@ -501,3 +638,63 @@ def test_pca_full_matches_matlab_missing_fixture() -> None:
 
     assert rms <= 1e-2
     assert_allclose(V_py, V_mat, rtol=1e-3, atol=1e-6)
+
+
+def test_pca_full_dense_fixture_smoke_map_and_ppca() -> None:
+    fixture = _fixture_path("legacy_pca_full_dense.mat")
+    if not fixture.exists():
+        pytest.skip("MATLAB dense fixture not available")
+
+    mat = loadmat(fixture, squeeze_me=True, struct_as_record=False)
+    x = np.asarray(mat["x"], dtype=float)
+    k = int(mat["k"])
+
+    res_map = pca_full(
+        x,
+        n_components=k,
+        algorithm="map",
+        maxiters=30,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+    res_ppca = pca_full(
+        x,
+        n_components=k,
+        algorithm="ppca",
+        maxiters=30,
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+
+    assert np.isfinite(float(res_map["V"]))
+    assert np.isfinite(float(res_ppca["V"]))
+    assert len(res_map["lc"]["rms"]) >= 1
+    assert len(res_ppca["lc"]["rms"]) >= 1
+
+
+def test_pca_full_missing_fixture_option_surface_smoke() -> None:
+    fixture = _fixture_path("legacy_pca_full_missing.mat")
+    if not fixture.exists():
+        pytest.skip("MATLAB missing-data fixture not available")
+
+    mat = loadmat(fixture, squeeze_me=True, struct_as_record=False)
+    x = np.asarray(mat["x"], dtype=float)
+    k = int(mat["k"])
+
+    out = pca_full(
+        x,
+        n_components=k,
+        algorithm="vb",
+        maxiters=40,
+        uniquesv=1,
+        rotate2pca=1,
+        cfstop=np.array([5, 1e-6, 1e-6]),
+        autosave=0,
+        display=0,
+        verbose=0,
+    )
+
+    assert len(out["lc"]["rms"]) == len(out["lc"]["cost"])
+    assert np.asarray(out["Isv"]).shape[0] == x.shape[1]

--- a/tests/test_perf_benchmarks.py
+++ b/tests/test_perf_benchmarks.py
@@ -1,0 +1,225 @@
+"""Performance benchmarks for compat_mode comparisons.
+
+These tests are marked ``perf`` and excluded from default test/CI runs.
+Run explicitly with:
+
+    pytest -q -m perf --benchmark-only
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from vbpca_py._pca_full import pca_full
+
+
+def _make_dense_with_missing(
+    n_features: int,
+    n_samples: int,
+    *,
+    seed: int,
+    missing_rate: float = 0.1,
+) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((n_features, n_samples))
+    missing = rng.random(x.shape) < missing_rate
+    x[missing] = np.nan
+    return x
+
+
+def _make_sparse(
+    n_features: int,
+    n_samples: int,
+    *,
+    seed: int,
+    zero_rate: float = 0.7,
+) -> sp.csr_matrix:
+    rng = np.random.default_rng(seed)
+    dense = rng.standard_normal((n_features, n_samples))
+    dense[rng.random(dense.shape) < zero_rate] = 0.0
+    return sp.csr_matrix(dense)
+
+
+def _octave_perf_available() -> bool:
+    has_octave = shutil.which("octave") is not None
+    has_oct2py = importlib.util.find_spec("oct2py") is not None
+    return has_octave and has_oct2py
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("compat_mode", ["strict_legacy", "modern"])
+def test_benchmark_pca_full_dense_modes(
+    benchmark: pytest.BenchmarkFixture,
+    compat_mode: str,
+) -> None:
+    """Benchmark dense pca_full runtime across compatibility modes."""
+    x = _make_dense_with_missing(30, 60, seed=123)
+
+    def run_once() -> dict[str, object]:
+        return pca_full(
+            x,
+            n_components=6,
+            maxiters=6,
+            algorithm="vb",
+            autosave=0,
+            display=0,
+            verbose=0,
+            rotate2pca=0,
+            compat_mode=compat_mode,
+        )
+
+    result = benchmark(run_once)
+    assert np.asarray(result["A"]).shape == (30, 6)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("compat_mode", ["strict_legacy", "modern"])
+def test_benchmark_pca_full_sparse_modes(
+    benchmark: pytest.BenchmarkFixture,
+    compat_mode: str,
+) -> None:
+    """Benchmark sparse pca_full runtime across compatibility modes."""
+    x_sparse = _make_sparse(40, 80, seed=456)
+
+    def run_once() -> dict[str, object]:
+        return pca_full(
+            x_sparse,
+            n_components=5,
+            maxiters=5,
+            algorithm="vb",
+            autosave=0,
+            display=0,
+            verbose=0,
+            rotate2pca=0,
+            compat_mode=compat_mode,
+        )
+
+    result = benchmark(run_once)
+    assert np.asarray(result["A"]).shape == (40, 5)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize(
+    ("n_features", "n_samples", "n_components"),
+    [(20, 40, 4), (40, 80, 8), (80, 160, 12)],
+)
+def test_benchmark_scaling_dense_modern(
+    benchmark: pytest.BenchmarkFixture,
+    n_features: int,
+    n_samples: int,
+    n_components: int,
+) -> None:
+    """Benchmark scaling for dense data as matrix size increases."""
+    x = _make_dense_with_missing(n_features, n_samples, seed=777)
+
+    def run_once() -> dict[str, object]:
+        return pca_full(
+            x,
+            n_components=n_components,
+            maxiters=4,
+            algorithm="vb",
+            autosave=0,
+            display=0,
+            verbose=0,
+            rotate2pca=0,
+            compat_mode="modern",
+        )
+
+    result = benchmark(run_once)
+    assert np.asarray(result["A"]).shape == (n_features, n_components)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize(
+    ("n_features", "n_samples", "n_components"),
+    [(30, 60, 4), (60, 120, 8), (120, 240, 12)],
+)
+def test_benchmark_scaling_sparse_modern(
+    benchmark: pytest.BenchmarkFixture,
+    n_features: int,
+    n_samples: int,
+    n_components: int,
+) -> None:
+    """Benchmark scaling for sparse data as matrix size increases."""
+    x_sparse = _make_sparse(n_features, n_samples, seed=888)
+
+    def run_once() -> dict[str, object]:
+        return pca_full(
+            x_sparse,
+            n_components=n_components,
+            maxiters=4,
+            algorithm="vb",
+            autosave=0,
+            display=0,
+            verbose=0,
+            rotate2pca=0,
+            compat_mode="modern",
+        )
+
+    result = benchmark(run_once)
+    assert np.asarray(result["A"]).shape == (n_features, n_components)
+
+
+@pytest.mark.perf
+@pytest.mark.skipif(
+    not _octave_perf_available(),
+    reason="Octave and oct2py are required for legacy pca_full.m benchmarking.",
+)
+def test_benchmark_octave_compare_dense(benchmark: pytest.BenchmarkFixture) -> None:
+    """Benchmark legacy Octave tools/pca_full.m on a dense problem."""
+    from oct2py import octave  # type: ignore[import-untyped]
+
+    x = _make_dense_with_missing(20, 40, seed=999)
+    tools_dir = Path(__file__).resolve().parents[1] / "tools"
+    octave.addpath(str(tools_dir))
+
+    def run_once() -> object:
+        return octave.feval(
+            "pca_full",
+            x,
+            4,
+            "maxiters",
+            4,
+            "algorithm",
+            "vb",
+            "autosave",
+            0,
+            "display",
+            0,
+            "verbose",
+            0,
+            "rotate2pca",
+            0,
+            nout=1,
+        )
+
+    result = benchmark(run_once)
+    assert result is not None
+
+
+@pytest.mark.perf
+def test_benchmark_python_compare_dense(benchmark: pytest.BenchmarkFixture) -> None:
+    """Benchmark Python pca_full counterpart for direct Octave comparison."""
+    x = _make_dense_with_missing(20, 40, seed=999)
+
+    def run_once() -> dict[str, object]:
+        return pca_full(
+            x,
+            n_components=4,
+            maxiters=4,
+            algorithm="vb",
+            autosave=0,
+            display=0,
+            verbose=0,
+            rotate2pca=0,
+            compat_mode="strict_legacy",
+        )
+
+    result = benchmark(run_once)
+    assert np.asarray(result["A"]).shape == (20, 4)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,6 +1,7 @@
 """Tests for missing-aware preprocessing utilities."""
 
 import numpy as np
+import pytest
 
 from vbpca_py.preprocessing import (
     AutoEncoder,
@@ -76,3 +77,61 @@ def test_autoencoder_mixed_schema_and_inverse() -> None:
     # Missing entries remain NaN
     assert str(x_inv[2, 0]) == "nan"
     assert str(x_inv[2, 1]) == "nan"
+
+
+def test_one_hot_encoder_unknown_category_raise() -> None:
+    x_train = np.array([["a"], ["b"]], dtype=object)
+    x_test = np.array([["c"]], dtype=object)
+
+    enc = MissingAwareOneHotEncoder(handle_unknown="raise")
+    enc.fit(x_train)
+    with pytest.raises(ValueError, match="Unknown category"):
+        enc.transform(x_test)
+
+
+def test_one_hot_encoder_unknown_category_ignore() -> None:
+    x_train = np.array([["a"], ["b"]], dtype=object)
+    x_test = np.array([["c"]], dtype=object)
+
+    enc = MissingAwareOneHotEncoder(handle_unknown="ignore")
+    z = enc.fit_transform(x_train)
+    assert z.shape == (2, 2)
+
+    z_test = enc.transform(x_test)
+    assert z_test.shape == (1, 2)
+    assert np.allclose(z_test, 0.0)
+
+
+def test_autoencoder_column_types_override() -> None:
+    x = np.array(
+        [
+            [1, 10.0],
+            [2, 20.0],
+            [3, 30.0],
+        ],
+        dtype=object,
+    )
+
+    auto = AutoEncoder(
+        column_types=["categorical", "continuous"],
+        cardinality_threshold=1,
+        continuous_scaler="minmax",
+    )
+    z = auto.fit_transform(x)
+    x_back = auto.inverse_transform(z)
+
+    assert z.shape[1] >= 2
+    assert x_back.shape == x.shape
+    assert x_back[0, 0] == 1
+
+
+def test_autoencoder_transform_before_fit_raises() -> None:
+    auto = AutoEncoder()
+    with pytest.raises(RuntimeError, match="not fitted"):
+        auto.transform(np.array([[1.0], [2.0]]))
+
+
+def test_autoencoder_inverse_transform_before_fit_raises() -> None:
+    auto = AutoEncoder()
+    with pytest.raises(RuntimeError, match="not fitted"):
+        auto.inverse_transform(np.array([[0.0], [1.0]]))

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,30 @@
+"""Public API surface tests for package-level exports."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+import vbpca_py
+
+
+def test_public_symbols_are_exported() -> None:
+    expected = {
+        "VBPCA",
+        "AutoEncoder",
+        "MissingAwareMinMaxScaler",
+        "MissingAwareOneHotEncoder",
+        "MissingAwareStandardScaler",
+        "SelectionConfig",
+        "select_n_components",
+    }
+
+    exported = set(vbpca_py.__all__)
+    assert expected.issubset(exported)
+
+    for name in expected:
+        assert hasattr(vbpca_py, name)
+
+
+def test_package_version_matches_distribution_metadata() -> None:
+    assert isinstance(vbpca_py.__version__, str)
+    assert vbpca_py.__version__ == version("vbpca_py")

--- a/tests/test_remove_empty.py
+++ b/tests/test_remove_empty.py
@@ -1,6 +1,7 @@
 """Tests for vbpca_py._rmempty.remove_empty_entries."""
 
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 from vbpca_py._remove_empty import remove_empty_entries
@@ -217,3 +218,36 @@ def test_x_probe_none_is_preserved() -> None:
     assert x_out.shape == (1, 1)
     assert x_probe_out is None
     assert init_out is None
+
+
+def test_sparse_cancellation_behavior_differs_by_compat_mode() -> None:
+    """strict_legacy may drop cancellation rows/cols; modern keeps nonzero-support."""
+    x = sp.csr_matrix(np.array([[-1.0, 1.0], [0.0, 0.0]], dtype=float))
+
+    x_strict, _, ir_strict, ic_strict, _ = remove_empty_entries(
+        x,
+        None,
+        None,
+        compat_mode="strict_legacy",
+    )
+    x_modern, _, ir_modern, ic_modern, _ = remove_empty_entries(
+        x,
+        None,
+        None,
+        compat_mode="modern",
+    )
+
+    assert np.array_equal(ir_strict, np.array([], dtype=int))
+    assert np.array_equal(ic_strict, np.array([0, 1]))
+    assert x_strict.shape == (0, 2)
+
+    assert np.array_equal(ir_modern, np.array([0]))
+    assert np.array_equal(ic_modern, np.array([0, 1]))
+    assert x_modern.shape == (1, 2)
+
+
+def test_remove_empty_invalid_compat_mode_raises() -> None:
+    """An invalid compat_mode should fail fast with a clear error."""
+    x = np.array([[1.0, np.nan], [2.0, 3.0]], dtype=float)
+    with pytest.raises(ValueError, match="compat_mode"):
+        remove_empty_entries(x, None, None, compat_mode="legacy")

--- a/tests/test_rms_regression.py
+++ b/tests/test_rms_regression.py
@@ -420,6 +420,80 @@ def test_sparse_reconstruction_error_validates_shapes() -> None:
         sparse_reconstruction_error(X, A_ok, S_bad_latent)
 
 
+def test_compute_rms_dense_sparse_consistency_on_observed_entries() -> None:
+    rng = np.random.default_rng(3210)
+    n1, n2, k = 6, 7, 3
+
+    obs = rng.random((n1, n2)) > 0.5
+    x_dense = rng.standard_normal((n1, n2))
+    x_dense[~obs] = 0.0
+
+    x_sparse = sp.csr_matrix(x_dense)
+    mask_dense = obs.astype(float)
+    mask_sparse = x_sparse.copy()
+    mask_sparse.data[:] = 1.0
+
+    A = rng.standard_normal((n1, k))
+    S = rng.standard_normal((k, n2))
+
+    cfg_dense = RmsConfig(n_observed=int(np.count_nonzero(mask_dense)), num_cpu=1)
+    cfg_sparse = RmsConfig(n_observed=int(x_sparse.nnz), num_cpu=1)
+
+    rms_dense, err_dense = compute_rms(x_dense, A, S, mask_dense, cfg_dense)
+    rms_sparse, err_sparse = compute_rms(x_sparse, A, S, mask_sparse, cfg_sparse)
+
+    rows, cols = x_sparse.nonzero()
+    np.testing.assert_allclose(rms_dense, rms_sparse, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        np.asarray(err_dense)[rows, cols],
+        err_sparse.toarray()[rows, cols],
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_sparse_reconstruction_error_num_cpu_invariant() -> None:
+    case = _mk_sparse_case(seed=777)
+    err_1 = sparse_reconstruction_error(case["X"], case["A"], case["S"], num_cpu=1)
+    err_4 = sparse_reconstruction_error(case["X"], case["A"], case["S"], num_cpu=4)
+
+    np.testing.assert_array_equal(err_1.indptr, err_4.indptr)
+    np.testing.assert_array_equal(err_1.indices, err_4.indices)
+    np.testing.assert_allclose(err_1.data, err_4.data, rtol=1e-12, atol=1e-12)
+
+
+def test_compute_rms_tall_and_wide_shapes_smoke() -> None:
+    rng = np.random.default_rng(909)
+    # tall matrix
+    x_tall = rng.standard_normal((20, 5))
+    m_tall = np.ones_like(x_tall)
+    a_tall = rng.standard_normal((20, 2))
+    s_tall = rng.standard_normal((2, 5))
+    r_tall, _ = compute_rms(
+        x_tall,
+        a_tall,
+        s_tall,
+        m_tall,
+        RmsConfig(n_observed=int(m_tall.size), num_cpu=1),
+    )
+
+    # wide matrix
+    x_wide = rng.standard_normal((5, 20))
+    m_wide = np.ones_like(x_wide)
+    a_wide = rng.standard_normal((5, 2))
+    s_wide = rng.standard_normal((2, 20))
+    r_wide, _ = compute_rms(
+        x_wide,
+        a_wide,
+        s_wide,
+        m_wide,
+        RmsConfig(n_observed=int(m_wide.size), num_cpu=1),
+    )
+
+    assert np.isfinite(r_tall)
+    assert np.isfinite(r_wide)
+
+
 # ----------------------------
 # Tests: Octave regression
 # ----------------------------

--- a/tests/test_runtime_robustness.py
+++ b/tests/test_runtime_robustness.py
@@ -1,0 +1,45 @@
+"""Runtime robustness tests for compiled helpers and low-level paths."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vbpca_py.subtract_mu_from_sparse import subtract_mu_from_sparse
+
+
+def test_subtract_mu_from_sparse_smoke() -> None:
+    # CSR for [[1, 0], [0, 2]]
+    data = np.array([1.0, 2.0], dtype=np.float64)
+    indices = np.array([0, 1], dtype=np.int32)
+    indptr = np.array([0, 1, 2], dtype=np.int32)
+    shape = (2, 2)
+    mu = np.array([1.0, 2.0], dtype=np.float64)
+
+    out = subtract_mu_from_sparse(data, indices, indptr, shape, mu)
+    assert out.shape == data.shape
+    assert np.all(np.isfinite(out))
+    assert np.all(out != 0.0)
+
+
+def test_subtract_mu_from_sparse_rejects_too_short_mu() -> None:
+    # CSR for [[1], [2]]
+    data = np.array([1.0, 2.0], dtype=np.float64)
+    indices = np.array([0, 0], dtype=np.int32)
+    indptr = np.array([0, 1, 2], dtype=np.int32)
+    shape = (2, 1)
+    mu = np.array([1.0], dtype=np.float64)  # too short for n_rows=2
+
+    with pytest.raises(Exception):
+        subtract_mu_from_sparse(data, indices, indptr, shape, mu)
+
+
+def test_subtract_mu_from_sparse_allows_longer_mu() -> None:
+    data = np.array([1.0], dtype=np.float64)
+    indices = np.array([0], dtype=np.int32)
+    indptr = np.array([0, 1], dtype=np.int32)
+    shape = (1, 1)
+    mu = np.array([1.0, 2.0], dtype=np.float64)  # valid: len(mu) >= n_rows
+
+    out = subtract_mu_from_sparse(data, indices, indptr, shape, mu)
+    assert out.shape == data.shape


### PR DESCRIPTION
This pull request introduces a new compatibility mode option (`compat_mode`) for handling missing data and empty row/column detection in Variational Bayesian PCA, providing both legacy and modern semantics. It also adds performance benchmarking tools, improves documentation, and refines packaging and test configuration.

**Compatibility mode improvements:**

* Added a `compat_mode` option (with values `"strict_legacy"` and `"modern"`) to control how missing data and empty rows/columns are handled throughout the codebase, including in mask building, observed index selection, and empty entry removal. This is enforced and validated in the options builder, and passed through all relevant internal APIs. (`src/vbpca_py/_pca_full.py`, `src/vbpca_py/_full_update.py`, `src/vbpca_py/_remove_empty.py`) [[1]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708R208) [[2]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708R253) [[3]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708R263-R266) [[4]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708R275) [[5]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708L291-R301) [[6]](diffhunk://#diff-6875a84d72c5da55f1eff348e0f09c5537139033837e89033718c996e04e2708R345-R365) [[7]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aL42-R42) [[8]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR60) [[9]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aL246-R251) [[10]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR926-R929) [[11]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR948-R962) [[12]](diffhunk://#diff-ab692d86da153fb235b0babf48eaa16ede02736cd61ec171373763a0e23b2a45L34-R37) [[13]](diffhunk://#diff-ab692d86da153fb235b0babf48eaa16ede02736cd61ec171373763a0e23b2a45R49-R54) [[14]](diffhunk://#diff-ab692d86da153fb235b0babf48eaa16ede02736cd61ec171373763a0e23b2a45R171-R172) [[15]](diffhunk://#diff-ab692d86da153fb235b0babf48eaa16ede02736cd61ec171373763a0e23b2a45R186-R209)

**Benchmarking and testing enhancements:**

* Added new `justfile` and documentation targets for running performance benchmarks, scaling tests, and Python vs Octave comparisons. Benchmarks are excluded from default CI runs and can be invoked explicitly. (`justfile`, `README.md`) [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R35-R54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R230-R242)
* Updated pytest configuration to exclude performance benchmarks from default runs and added a `perf` marker for explicit invocation. (`pyproject.toml`)

**Documentation improvements:**

* Expanded the `README.md` with a statement of need, clarified the scope and reference behavior, documented the new `compat_mode` option, and improved API and benchmarking instructions. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R139) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R155) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R230-R242)

**Packaging and metadata updates:**

* Added `py.typed` marker for type hinting support and made minor corrections to `MANIFEST.in` and `pyproject.toml` for license and classifier fields. Cleaned up unused imports in `setup.py` and removed unnecessary package metadata from `setup.py` (now handled by `pyproject.toml`). (`MANIFEST.in`, `pyproject.toml`, `setup.py`) [[1]](diffhunk://#diff-41d5a52589e0480be9c099d2bba7a8135b8b0d71bcbb8df3582a8df1c2295003L6-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L14-R14) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L7-R7) [[5]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L72-L89)

**Testing improvements:**

* Added new tests for convergence message content regarding RMS and cost plateaus, ensuring correct reporting of window information. (`tests/test_converge.py`)