### PR TITLE
fix: add 'rms' to _Metric type hint and handle it in _metric_value

### DIFF
--- a/src/vbpca_py/model_selection.py
+++ b/src/vbpca_py/model_selection.py
@@ -27,7 +27,7 @@ __all__ = ["SelectionConfig", "select_n_components"]
 
 logger = logging.getLogger(__name__)
 
-_Metric = Literal["prms", "cost"]
+_Metric = Literal["rms", "prms", "cost"]
 _AllowedFloat = (
     SupportsFloat
     | SupportsIndex
@@ -94,7 +94,9 @@ def _to_float(val: object | None) -> float:
         return float("nan")
 
 
-def _metric_value(metric: _Metric, rms: float, prms: float, cost: float) -> float:  # noqa: ARG001
+def _metric_value(metric: _Metric, rms: float, prms: float, cost: float) -> float:
+    if metric == "rms":
+        return rms if np.isfinite(rms) else cost
     if metric == "prms":
         return prms if np.isfinite(prms) else cost
     return cost if np.isfinite(cost) else prms


### PR DESCRIPTION
Fixes #15

## Problem
The `_Metric` type alias was `Literal["prms", "cost"]` but `SelectionConfig` accepted `"rms"` at runtime. This caused mypy to flag valid `metric="rms"" usage.

## Changes
- Added `"rms"` to `_Metric` Literal
- Added `rms` handling in `_metric_value()` function