### PR TITLE
Store subspace angle in learning curves

### DIFF
--- a/src/vbpca_py/_converge.py
+++ b/src/vbpca_py/_converge.py
@@ -356,8 +356,10 @@ def _angle_for_iteration(state: ConvergenceState) -> tuple[float, float | None]:
     angle_every = max(1, _coerce_int(cast("Any", state.opts.get("angle_every", 1)), 1))
     iter_index = len(state.lc["rms"])
     if iter_index % angle_every != 0:
+        state.lc["angle"].append(float("nan"))
         return float("inf"), None
 
     angles = subspace_angles(state.loadings, state.loadings_old)
     angle_a = float(np.max(angles))
+    state.lc["angle"].append(angle_a)
     return angle_a, angle_a

--- a/src/vbpca_py/_monitoring.py
+++ b/src/vbpca_py/_monitoring.py
@@ -651,6 +651,7 @@ def _initial_monitoring(
         "prms": [float(prms)],
         "time": [0.0],
         "cost": [float("nan")],
+        "angle": [float("nan")],
         "phase_scores_sec": [0.0],
         "phase_loadings_sec": [0.0],
         "phase_rms_sec": [0.0],

--- a/tests/test_pca_full.py
+++ b/tests/test_pca_full.py
@@ -1515,3 +1515,65 @@ def test_pca_full_hp_va_affects_ard_pruning() -> None:
     va_strong = np.asarray(out_strong["Va"], dtype=float)
     # Different priors → different component variances.
     assert not np.allclose(va_weak, va_strong, rtol=0.1)
+
+
+def test_lc_angle_stored_and_correct_length() -> None:
+    """lc["angle"] should exist and have the same length as lc["rms"]."""
+    rng = np.random.default_rng(520)
+    x = rng.standard_normal((8, 12))
+
+    result = pca_full(x, n_components=3, maxiters=10, verbose=0)
+
+    lc = result["lc"]
+    assert "angle" in lc
+    assert len(lc["angle"]) == len(lc["rms"])
+
+
+def test_lc_angle_first_entry_is_nan() -> None:
+    """The initial angle entry (before any iteration) should be NaN."""
+    rng = np.random.default_rng(521)
+    x = rng.standard_normal((8, 12))
+
+    result = pca_full(x, n_components=3, maxiters=5, verbose=0)
+
+    assert np.isnan(result["lc"]["angle"][0])
+
+
+def test_lc_angle_subsequent_entries_are_finite() -> None:
+    """After the first iteration, angle values should be finite in [0, pi/2]."""
+    rng = np.random.default_rng(522)
+    x = rng.standard_normal((8, 12))
+
+    result = pca_full(x, n_components=3, maxiters=10, verbose=0)
+
+    angles = np.asarray(result["lc"]["angle"][1:], dtype=float)
+    assert np.all(np.isfinite(angles))
+    assert np.all(angles >= 0.0)
+    assert np.all(angles <= np.pi / 2 + 1e-10)
+
+
+def test_lc_angle_with_angle_every_has_nan_on_skipped() -> None:
+    """When angle_every > 1, skipped iterations should store NaN."""
+    rng = np.random.default_rng(523)
+    x = rng.standard_normal((8, 12))
+
+    result = pca_full(
+        x,
+        n_components=3,
+        maxiters=8,
+        verbose=0,
+        angle_every=3,
+    )
+
+    lc = result["lc"]
+    angles = lc["angle"]
+    assert len(angles) == len(lc["rms"])
+    # iter_index = len(rms) at call time = i+1 for lc index i.
+    # Angle computed when (i+1) % angle_every == 0; NaN otherwise.
+    for i, a in enumerate(angles):
+        if i == 0:
+            assert np.isnan(a), "index 0 should be NaN (init)"
+        elif (i + 1) % 3 == 0:
+            assert np.isfinite(a), f"index {i} should be finite (angle_every=3)"
+        else:
+            assert np.isnan(a), f"index {i} should be NaN (skipped)"


### PR DESCRIPTION
## Summary

Store the subspace angle in the learning-curve dictionary (`lc["angle"]`) so convergence diagnostics are available without re-computation.

## Changes

| File | Change |
|---|---|
| `_monitoring.py` | Initialise `lc["angle"] = [nan]` alongside existing keys |
| `_converge.py` | Append angle (or `nan` when skipped by `angle_every`) in `_angle_for_iteration()` |
| `tests/test_pca_full.py` | 4 new tests: existence & length, first-entry NaN, finite bounds [0, π/2], `angle_every` skip pattern |

## Notes

- Zero API surface change — `lc` is the same dict type, just gains one key
- Prerequisite for #36 (`learning_curves_` attribute on the estimator)
- 405 tests pass, 89.93% coverage

Closes #52