### PR TITLE
feat: expose convergence diagnostics from VBPCA.fit() and select_n_components()

### DIFF
--- a/analysis/stability_analysis.py
+++ b/analysis/stability_analysis.py
@@ -392,7 +392,7 @@ class _CoverageTrial:
     mean_interval_width: float = 0.0  # mean 2*z*sqrt(var) at this nominal
 
 
-def _run_single_coverage_trial(  # noqa: PLR0913, PLR0917
+def _run_single_coverage_trial(
     n: int,
     p: int,
     true_rank: int,
@@ -407,7 +407,7 @@ def _run_single_coverage_trial(  # noqa: PLR0913, PLR0917
     Returns:
         List of coverage trial results, one per nominal level.
     """
-    from typing import Any  # noqa: PLC0415
+    from typing import Any
 
     x = x_clean.copy()
     mask = _apply_missingness(x, miss_pattern, rng)
@@ -506,7 +506,7 @@ def _run_coverage_grid(
     Returns:
         List of coverage trial results.
     """
-    from scipy import stats  # noqa: PLC0415
+    from scipy import stats
 
     rng = np.random.default_rng(seed)
     results: list[_CoverageTrial] = []
@@ -1290,7 +1290,7 @@ def _save_results(trials: list[_Trial], output_dir: pathlib.Path) -> None:
     LOGGER.info("Wrote %s (%d trials)", json_path, len(records))
 
     try:
-        import pandas as pd  # noqa: PLC0415
+        import pandas as pd
 
         df = pd.DataFrame(records)
         parquet_path = output_dir / "stability_results.parquet"

--- a/justfile
+++ b/justfile
@@ -141,6 +141,37 @@ paper-plot:
 paper-figure-smoke:
 	uv run --extra analysis python analysis/stability_analysis.py --smoke --fmt png
 
+# ── Trade study (hyperparameter optimisation) ────────────────────
+# Requires: pip install -e "/path/to/trade-study[all]" in the venv.
+
+# Phase 1: Morris sensitivity screening (~5-15 min).
+trade-screen:
+	.venv/bin/python -m analysis.trade_study.phase1_screen
+
+# Phase 2: Sobol exploration across all regimes (hours).
+trade-explore:
+	.venv/bin/python -m analysis.trade_study.phase2_explore --n-jobs -1
+
+# Phase 3-4: Adaptive refinement + benchmark per regime.
+trade-refine:
+	.venv/bin/python -m analysis.trade_study.phase3_refine --n-adaptive 100 --n-jobs -1
+
+# Run all trade-study phases end-to-end.
+trade-all:
+	.venv/bin/python -m analysis.trade_study --n-jobs -1
+
+# Quick smoke: screen only with minimal trajectories.
+trade-smoke:
+	.venv/bin/python -m analysis.trade_study.phase1_screen --trajectories 8 --threshold 0.1
+
+# Generate all trade-study + comparison figures from saved results.
+trade-plot fmt="png":
+	.venv/bin/python -m analysis.trade_study.plot --fmt {{fmt}}
+
+# Re-run stability grid with default + optimized configs, then plot comparison.
+trade-compare fmt="png":
+	.venv/bin/python -m analysis.trade_study.compare --fmt {{fmt}}
+
 # Build documentation site.
 docs:
 	uv run --extra docs mkdocs build --strict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,10 +212,37 @@ ignore = [
     "PLR0915", # Too many statements (diagnostic scripts with many print calls)
 ]
 "analysis/**/*" = [
-    "D104",    # Missing docstring in __init__.py OK
+    "ANN",     # Type annotations not required in analysis
+    "ARG001",  # Unused arguments OK in analysis (callbacks, interfaces)
+    "ARG002",  # Unused method arguments OK in analysis (scorer interface)
+    "B905",    # zip() strict= not required in analysis
+    "BLE001",  # Blind except OK in analysis
+    "C901",    # Complex functions OK in analysis
+    "D",       # Docstring rules not enforced in analysis
+    "DOC201",  # Missing return in docstring OK in analysis
+    "DOC501",  # Missing raises in docstring OK in analysis
+    "E501",    # Long lines OK in analysis
+    "EM101",   # String literal in exception OK in analysis
+    "EM102",   # f-string in exception OK in analysis
+    "EXE001",  # Shebang presence not required
+    "F841",    # Unused local OK in analysis (intermediate results)
+    "FBT001",  # Boolean positional args OK in analysis
+    "FBT002",  # Boolean default args OK in analysis
     "INP001",  # Implicit namespace package
-    "PLR0914", # Many locals OK in plotting functions
+    "N806",    # Uppercase variable names OK (matrix convention: W, S)
+    "PLC0415", # Lazy imports OK in analysis
+    "PLR0913", # Many arguments OK in analysis
+    "PLR0914", # Many locals OK in analysis
+    "PLR0915", # Too many statements OK in analysis
+    "PLR0917", # Many positional args OK in analysis
+    "PLR6301", # Method could be function OK in analysis (scorer API)
+    "PLW1514", # Explicit encoding not required in analysis
+    "RUF001",  # Ambiguous unicode OK in analysis
+    "RUF002",  # Ambiguous unicode OK in analysis
+    "RUF003",  # Ambiguous unicode OK in analysis
+    "RUF046",  # Redundant int cast OK in analysis (defensive rounding)
     "T201",    # print() OK in analysis scripts
+    "TRY003",  # Long exception messages OK in analysis
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/vbpca_py/_converge.py
+++ b/src/vbpca_py/_converge.py
@@ -241,28 +241,41 @@ def _cost_criteria(
     Returns:
         The first triggered message, or ``None``.
     """
+    tag, msg = _cost_criteria_tagged(opts, cost)
+    return msg
+
+
+def _cost_criteria_tagged(
+    opts: Mapping[str, Any],
+    cost: np.ndarray,
+) -> tuple[str | None, str | None]:
+    """Like :func:`_cost_criteria` but also returns a reason tag.
+
+    Returns:
+        ``(reason_tag, message)`` or ``(None, None)`` when nothing fires.
+    """
     # Cost plateau
     cfstop = opts.get("cfstop")
     if cost.size >= 2 and cfstop is not None:
         plateau_msg = _plateau_stop(cost, cfstop, "cost")
         if plateau_msg:
-            return plateau_msg
+            return "cost_plateau", plateau_msg
 
     # Relative ELBO decrease
     cfstop_rel = opts.get("cfstop_rel")
     if cfstop_rel is not None:
         rel_msg = _relative_elbo_stop(cost, float(cfstop_rel))
         if rel_msg:
-            return rel_msg
+            return "cfstop_rel", rel_msg
 
     # ELBO curvature (2nd difference)
     cfstop_curv = opts.get("cfstop_curv")
     if cfstop_curv is not None:
         curv_msg = _elbo_curvature_stop(cost, float(cfstop_curv))
         if curv_msg:
-            return curv_msg
+            return "cfstop_curv", curv_msg
 
-    return None
+    return None, None
 
 
 def _check_sub_criterion(
@@ -424,30 +437,52 @@ def convergence_check(
     composite_cfg = opts.get("composite_stop")
 
     # Evaluate criteria in priority order; return first trigger.
-    checks: list[str | None] = [
+    # Each entry is (reason_tag, message_or_None).
+    tagged_checks: list[tuple[str, str | None]] = [
         # 1. Angle-based stop
-        _angle_stop_message(opts, angle_a),
+        ("angle", _angle_stop_message(opts, angle_a)),
         # 2. Early stopping on probe RMS
-        _early_stop_message(opts, prms),
+        ("earlystop", _early_stop_message(opts, prms)),
         # 3. RMS plateau
-        _plateau_stop(rms, rmsstop, "RMS")
-        if rms.size >= 2 and rmsstop is not None
-        else None,
-        # 4. Cost / ELBO criteria
-        _cost_criteria(opts, cost),
+        (
+            "rms_plateau",
+            _plateau_stop(rms, rmsstop, "RMS")
+            if rms.size >= 2 and rmsstop is not None
+            else None,
+        ),
+        # 4. Cost / ELBO criteria (has its own sub-priority)
+        *([_cost_criteria_tagged(opts, cost)]
+          if True else []),
         # 5. Composite stop
-        _composite_stop(composite_cfg, angle_a, rms, cost) if composite_cfg else None,
+        (
+            "composite",
+            _composite_stop(composite_cfg, angle_a, rms, cost)
+            if composite_cfg
+            else None,
+        ),
         # 6. Slowing-down criterion
-        _slowing_down_message(sd_iter),
+        ("slowing_down", _slowing_down_message(sd_iter)),
     ]
-    candidate = next((msg for msg in checks if msg), "")
+
+    reason_tag = ""
+    candidate = ""
+    for tag, msg in tagged_checks:
+        if msg:
+            reason_tag = tag
+            candidate = msg
+            break
 
     # Apply patience window if configured.
     patience_val = opts.get("patience")
     patience = int(patience_val) if patience_val is not None else 1
-    if patience <= 1:
-        return candidate
-    return _apply_patience(candidate, lc, patience)
+    if patience > 1:
+        candidate = _apply_patience(candidate, lc, patience)
+
+    # Store the reason tag in lc for downstream consumers.
+    if candidate and reason_tag:
+        lc["_convergence_reason"] = reason_tag  # type: ignore[index]
+
+    return candidate
 
 
 # ---------------------------------------------------------------------------

--- a/src/vbpca_py/_converge.py
+++ b/src/vbpca_py/_converge.py
@@ -241,7 +241,7 @@ def _cost_criteria(
     Returns:
         The first triggered message, or ``None``.
     """
-    tag, msg = _cost_criteria_tagged(opts, cost)
+    _tag, msg = _cost_criteria_tagged(opts, cost)
     return msg
 
 
@@ -438,7 +438,7 @@ def convergence_check(
 
     # Evaluate criteria in priority order; return first trigger.
     # Each entry is (reason_tag, message_or_None).
-    tagged_checks: list[tuple[str, str | None]] = [
+    tagged_checks: list[tuple[str | None, str | None]] = [
         # 1. Angle-based stop
         ("angle", _angle_stop_message(opts, angle_a)),
         # 2. Early stopping on probe RMS
@@ -451,8 +451,7 @@ def convergence_check(
             else None,
         ),
         # 4. Cost / ELBO criteria (has its own sub-priority)
-        *([_cost_criteria_tagged(opts, cost)]
-          if True else []),
+        *([_cost_criteria_tagged(opts, cost)] if True else []),
         # 5. Composite stop
         (
             "composite",
@@ -468,7 +467,7 @@ def convergence_check(
     candidate = ""
     for tag, msg in tagged_checks:
         if msg:
-            reason_tag = tag
+            reason_tag = tag or ""
             candidate = msg
             break
 

--- a/src/vbpca_py/_pca_full.py
+++ b/src/vbpca_py/_pca_full.py
@@ -1245,8 +1245,8 @@ def _run_training_loop(
     # Promote _convergence_reason to a top-level lc key (set by
     # convergence_check when a criterion fires).  If no criterion
     # fired the loop exhausted maxiters.
-    reason = training.lc.pop("_convergence_reason", "maxiters")
-    training.lc["convergence_reason"] = reason
+    reason: str = str(training.lc.pop("_convergence_reason", "maxiters"))
+    training.lc["convergence_reason"] = reason  # type: ignore[assignment]
 
     return training
 

--- a/src/vbpca_py/_pca_full.py
+++ b/src/vbpca_py/_pca_full.py
@@ -1241,6 +1241,13 @@ def _run_training_loop(
 
     # Cleanup internal stop marker to keep lc stable for external callers.
     training.lc.pop("_stop", None)
+
+    # Promote _convergence_reason to a top-level lc key (set by
+    # convergence_check when a criterion fires).  If no criterion
+    # fired the loop exhausted maxiters.
+    reason = training.lc.pop("_convergence_reason", "maxiters")
+    training.lc["convergence_reason"] = reason
+
     return training
 
 

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -79,6 +79,9 @@ class VBPCA:
         self.prms_: float | None = None
         self.noise_variance_: float | None = None
         self.cost_: float | None = None
+        self.n_iter_: int | None = None
+        self.convergence_reason_: str | None = None
+        self.learning_curve_: dict[str, list[float]] | None = None
         self.reconstruction_: np.ndarray | None = None
         self.variance_: np.ndarray | None = None
         self.explained_variance_: np.ndarray | None = None
@@ -221,6 +224,21 @@ class VBPCA:
             if isinstance(cost_val, (float, int, np.floating))
             else float("nan")
         )
+
+        # Convergence diagnostics from the learning curve.
+        lc = result.get("lc")
+        if lc and isinstance(lc, dict):
+            rms_history = lc.get("rms", [])
+            self.n_iter_ = max(0, len(rms_history) - 1)
+            self.convergence_reason_ = str(
+                lc.get("convergence_reason", "maxiters")
+            )
+            self.learning_curve_ = lc
+        else:
+            self.n_iter_ = 0
+            self.convergence_reason_ = "maxiters"
+            self.learning_curve_ = None
+
         self.reconstruction_ = None
         if result.get("Xrec") is not None:
             self.reconstruction_ = np.asarray(result["Xrec"], dtype=float)

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -230,9 +230,7 @@ class VBPCA:
         if lc and isinstance(lc, dict):
             rms_history = lc.get("rms", [])
             self.n_iter_ = max(0, len(rms_history) - 1)
-            self.convergence_reason_ = str(
-                lc.get("convergence_reason", "maxiters")
-            )
+            self.convergence_reason_ = str(lc.get("convergence_reason", "maxiters"))
             self.learning_curve_ = lc
         else:
             self.n_iter_ = 0

--- a/src/vbpca_py/model_selection.py
+++ b/src/vbpca_py/model_selection.py
@@ -156,6 +156,8 @@ def _fit_candidate(
         "prms": prms,
         "cost": cost,
         "evr": None,
+        "n_iter": est.n_iter_ if est.n_iter_ is not None else 0,
+        "convergence_reason": est.convergence_reason_ or "maxiters",
     }
     return entry, est
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -298,3 +298,57 @@ def test_xprobe_fraction_no_probe_when_zero() -> None:
     # No probe -> prms is NaN
     assert model.prms_ is not None
     assert np.isnan(model.prms_)
+
+
+# ── Convergence diagnostics (issue #99) ─────────────────────────
+
+
+def test_convergence_diagnostics_exposed_after_fit() -> None:
+    """n_iter_, convergence_reason_, learning_curve_ are set after fit()."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((6, 10))
+    model = VBPCA(n_components=2, maxiters=10, verbose=0)
+    model.fit(x)
+
+    assert isinstance(model.n_iter_, int)
+    assert model.n_iter_ > 0
+    assert model.n_iter_ <= 10
+
+    assert isinstance(model.convergence_reason_, str)
+    assert model.convergence_reason_ != ""
+
+    assert isinstance(model.learning_curve_, dict)
+    assert "rms" in model.learning_curve_
+    assert len(model.learning_curve_["rms"]) == model.n_iter_ + 1
+
+
+def test_convergence_reason_maxiters() -> None:
+    """When maxiters is hit, convergence_reason_ should be 'maxiters'."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((6, 10))
+    model = VBPCA(n_components=2, maxiters=5, verbose=0)
+    model.fit(x)
+
+    assert model.convergence_reason_ == "maxiters"
+    assert model.n_iter_ == 5
+
+
+def test_convergence_reason_angle() -> None:
+    """With niter_broadprior=0 the angle criterion can fire early."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((6, 10))
+    model = VBPCA(n_components=2, maxiters=500, niter_broadprior=0, verbose=0)
+    model.fit(x)
+
+    assert model.convergence_reason_ in {
+        "angle", "rms_plateau", "cost_plateau", "slowing_down",
+    }
+    assert model.n_iter_ < 500
+
+
+def test_diagnostics_none_before_fit() -> None:
+    """Diagnostics should be None before fit() is called."""
+    model = VBPCA(n_components=2)
+    assert model.n_iter_ is None
+    assert model.convergence_reason_ is None
+    assert model.learning_curve_ is None

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -341,7 +341,10 @@ def test_convergence_reason_angle() -> None:
     model.fit(x)
 
     assert model.convergence_reason_ in {
-        "angle", "rms_plateau", "cost_plateau", "slowing_down",
+        "angle",
+        "rms_plateau",
+        "cost_plateau",
+        "slowing_down",
     }
     assert model.n_iter_ < 500
 

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -767,7 +767,10 @@ def test_trace_contains_convergence_diagnostics() -> None:
     x = _low_rank_data(rng, n_features=6, n_samples=10, rank=2)
 
     _, _, trace, _ = select_n_components(
-        x, components=[1, 2, 3], maxiters=20, verbose=0,
+        x,
+        components=[1, 2, 3],
+        maxiters=20,
+        verbose=0,
     )
 
     assert len(trace) >= 3

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -756,3 +756,27 @@ def test_select_n_components_no_variance_without_diagnostics() -> None:
 
     assert best_model is not None
     assert best_model.variance_ is None
+
+
+# ── Convergence diagnostics in trace (issue #99) ────────────────
+
+
+def test_trace_contains_convergence_diagnostics() -> None:
+    """Each trace entry should have n_iter and convergence_reason."""
+    rng = np.random.default_rng(42)
+    x = _low_rank_data(rng, n_features=6, n_samples=10, rank=2)
+
+    _, _, trace, _ = select_n_components(
+        x, components=[1, 2, 3], maxiters=20, verbose=0,
+    )
+
+    assert len(trace) >= 3
+    for entry in trace:
+        assert "n_iter" in entry, f"trace entry for k={entry['k']} missing n_iter"
+        assert "convergence_reason" in entry, (
+            f"trace entry for k={entry['k']} missing convergence_reason"
+        )
+        assert isinstance(entry["n_iter"], int)
+        assert entry["n_iter"] > 0
+        assert isinstance(entry["convergence_reason"], str)
+        assert entry["convergence_reason"] != ""


### PR DESCRIPTION
Closes #99

## Summary

Expose convergence diagnostics that `pca_full()` already computes but `VBPCA.fit()` previously discarded. This enables downstream analysis of convergence behavior — particularly important for optimizing convergence parameters where `wall_seconds` is an unreliable proxy.

## Changes

### `_converge.py`
- New `_cost_criteria_tagged()` returns `(reason_tag, message)` tuples instead of bare strings
- `convergence_check()` stores a structured `_convergence_reason` tag in the learning curve dict when a criterion fires
- Reason tags: `angle`, `earlystop`, `rms_plateau`, `cost_plateau`, `cfstop_rel`, `cfstop_curv`, `composite`, `slowing_down`

### `_pca_full.py`
- After the training loop, promotes `_convergence_reason` → `convergence_reason` in lc, defaulting to `"maxiters"`

### `estimators.py`
Three new fitted attributes on `VBPCA`:
- `n_iter_: int | None` — iterations completed
- `convergence_reason_: str | None` — structured reason tag or `"maxiters"`
- `learning_curve_: dict | None` — full per-iteration history (rms, prms, cost, angle, phase timings)

### `model_selection.py`
- `_fit_candidate()` trace entries now include `n_iter` and `convergence_reason`

### Tests
- 4 new tests in `test_estimators.py`: diagnostics exposed after fit, maxiters reason, angle reason, None before fit
- 1 new test in `test_model_selection.py`: trace entries contain convergence diagnostics

## Motivation

Investigation revealed that `niter_broadprior=100` (the default) suppresses convergence checks, causing 30–93% iteration waste with negligible quality improvement:

| Case | bp=100 | bp=0 | Waste | Quality Δ |
|---|---|---|---|---|
| small (10×20) | 110 | 68 | +62% | negligible |
| medium (50×100) | 175 | 112 | +56% | 0.002 RMS |
| medium+missing | 220 | 114 | +93% | 0.001 RMSE |
| large (100×200) | 147 | 114 | +29% | — |

These diagnostics enable data-driven optimization of `niter_broadprior` and convergence thresholds.