### PR TITLE
Add configurable convergence criterion ordering and per-criterion ena…

### DIFF
--- a/docs/concepts/convergence.md
+++ b/docs/concepts/convergence.md
@@ -86,3 +86,26 @@ $N$ consecutive iterations before convergence is declared.
 - **Broad-prior warmup:** during the first `niter_broadprior` iterations (default
   100), stopping messages are suppressed when `use_prior` is active, allowing the
   model to settle before ARD engages.
+
+## Criterion ordering — `criterion_order`
+
+By default, criteria are evaluated in a fixed priority order (angle first,
+slowing-down last). The first criterion that fires wins. You can change
+this ordering with `criterion_order`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `criterion_order` | `None` (use default) | List of criterion names in priority order |
+
+Valid criterion names: `angle`, `earlystop`, `rms_plateau`, `cost`,
+`composite`, `slowing_down`.
+
+## Per-criterion enable/disable — `convergence_criteria`
+
+Selectively disable individual criteria without zeroing their thresholds.
+Disabled criteria are still evaluated for diagnostics but excluded from the
+stop decision.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `convergence_criteria` | `None` (all enabled) | Dict mapping criterion names to booleans |

--- a/docs/howto/convergence.md
+++ b/docs/howto/convergence.md
@@ -97,3 +97,50 @@ model.fit(X_train, mask=~np.isnan(X_train), xprobe=X_probe)
 
 See [Convergence Criteria](../concepts/convergence.md) for a reference of all
 options and their defaults.
+
+## Prioritize ELBO over angle stopping
+
+If the subspace-angle criterion fires too early (e.g. under heavy
+missingness), put cost-based criteria first:
+
+```python
+model = VBPCA(
+    n_components=5,
+    criterion_order=["cost", "composite", "rms_plateau", "angle", "earlystop", "slowing_down"],
+    cfstop=[200, 1e-6, 1e-5],
+)
+model.fit(X, mask=mask)
+```
+
+## Disable angle-based stopping
+
+Disable angle without setting `minangle=0` — this way diagnostic logging
+still records the subspace angle each iteration:
+
+```python
+model = VBPCA(
+    n_components=5,
+    convergence_criteria={"angle": False},
+)
+model.fit(X, mask=mask)
+```
+
+## Combine ordering and disabling
+
+You can use both options together.  For example, run only ELBO and
+composite criteria, with ELBO checked first:
+
+```python
+model = VBPCA(
+    n_components=5,
+    criterion_order=["cost", "composite", "rms_plateau", "angle", "earlystop", "slowing_down"],
+    convergence_criteria={
+        "angle": False,
+        "earlystop": False,
+        "rms_plateau": False,
+        "slowing_down": False,
+    },
+    cfstop=[200, 1e-6, 1e-5],
+)
+model.fit(X, mask=mask)
+```

--- a/src/vbpca_py/_converge.py
+++ b/src/vbpca_py/_converge.py
@@ -24,6 +24,18 @@ Matrix = Array | Sparse
 
 logger = logging.getLogger(__name__)
 
+#: Default priority order used by :func:`convergence_check`.
+DEFAULT_CRITERION_ORDER: list[str] = [
+    "angle",
+    "earlystop",
+    "rms_plateau",
+    "cost",
+    "composite",
+    "slowing_down",
+]
+
+_VALID_CRITERION_NAMES: frozenset[str] = frozenset(DEFAULT_CRITERION_ORDER)
+
 
 def _coerce_int(
     val: SupportsInt | SupportsIndex | str | bytes | bytearray | None,
@@ -412,15 +424,14 @@ def convergence_check(
 ) -> str:
     """Check convergence criteria and return a human-readable message.
 
-    The following criteria are evaluated **in order**; the first one that
-    triggers returns a non-empty message, otherwise an empty string:
+    Criteria are evaluated in the order given by ``opts["criterion_order"]``
+    (defaulting to :data:`DEFAULT_CRITERION_ORDER`).  The first **enabled**
+    criterion that triggers returns a non-empty message.
 
-    1. Subspace-angle stop (``minangle``).
-    2. Early stopping based on probe RMS (``earlystop``).
-    3. RMS plateau stop (``rmsstop = [window, abs_tol, rel_tol]``).
-    4. Cost / ELBO criteria (``cfstop``, ``cfstop_rel``, ``cfstop_curv``).
-    5. Composite stop (``composite_stop``).
-    6. "Slowing-down'' stop based on ``sd_iter`` (gradient backtracking).
+    Individual criteria can be disabled via ``opts["convergence_criteria"]``,
+    a ``dict[str, bool]``.  Disabled criteria are still evaluated (their
+    results are available for diagnostics) but excluded from the stop
+    decision.
 
     When ``patience`` is set (> 1), the winning criterion must fire for
     that many **consecutive** iterations before the message is returned.
@@ -436,36 +447,36 @@ def convergence_check(
     rmsstop = opts.get("rmsstop")
     composite_cfg = opts.get("composite_stop")
 
-    # Evaluate criteria in priority order; return first trigger.
-    # Each entry is (reason_tag, message_or_None).
-    tagged_checks: list[tuple[str | None, str | None]] = [
-        # 1. Angle-based stop
-        ("angle", _angle_stop_message(opts, angle_a)),
-        # 2. Early stopping on probe RMS
-        ("earlystop", _early_stop_message(opts, prms)),
-        # 3. RMS plateau
-        (
+    # Build the full check registry — always evaluate all criteria.
+    all_checks: dict[str, tuple[str | None, str | None]] = {
+        "angle": ("angle", _angle_stop_message(opts, angle_a)),
+        "earlystop": ("earlystop", _early_stop_message(opts, prms)),
+        "rms_plateau": (
             "rms_plateau",
             _plateau_stop(rms, rmsstop, "RMS")
             if rms.size >= 2 and rmsstop is not None
             else None,
         ),
-        # 4. Cost / ELBO criteria (has its own sub-priority)
-        *([_cost_criteria_tagged(opts, cost)] if True else []),
-        # 5. Composite stop
-        (
+        "cost": _cost_criteria_tagged(opts, cost),
+        "composite": (
             "composite",
             _composite_stop(composite_cfg, angle_a, rms, cost)
             if composite_cfg
             else None,
         ),
-        # 6. Slowing-down criterion
-        ("slowing_down", _slowing_down_message(sd_iter)),
-    ]
+        "slowing_down": ("slowing_down", _slowing_down_message(sd_iter)),
+    }
+
+    # Determine ordering and enablement.
+    order = opts.get("criterion_order") or DEFAULT_CRITERION_ORDER
+    enabled: dict[str, bool] = opts.get("convergence_criteria") or {}
 
     reason_tag = ""
     candidate = ""
-    for tag, msg in tagged_checks:
+    for name in order:
+        if not enabled.get(name, True):
+            continue
+        tag, msg = all_checks[name]
         if msg:
             reason_tag = tag or ""
             candidate = msg

--- a/src/vbpca_py/_pca_full.py
+++ b/src/vbpca_py/_pca_full.py
@@ -25,7 +25,11 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
     from pathlib import Path
 
-from ._converge import ConvergenceState, _log_and_check_convergence
+from ._converge import (
+    _VALID_CRITERION_NAMES,
+    ConvergenceState,
+    _log_and_check_convergence,
+)
 from ._expand import _add_m_cols, _add_m_rows
 from ._full_update import (
     BiasState,
@@ -1918,6 +1922,44 @@ def _pack_result(
 # ---------------------------------------------------------------------------
 
 
+def _validate_convergence_opts(opts: dict[str, object]) -> None:
+    """Validate ``criterion_order`` and ``convergence_criteria`` in *opts*.
+
+    Raises:
+        TypeError: If the values have wrong types.
+        ValueError: If unknown criterion names are supplied.
+    """
+    crit_order = opts.get("criterion_order")
+    if crit_order is not None:
+        if not isinstance(crit_order, (list, tuple)):
+            msg = "criterion_order must be a list of criterion names."
+            raise TypeError(msg)
+        unknown = set(crit_order) - _VALID_CRITERION_NAMES
+        if unknown:
+            msg = (
+                "Unknown criterion name(s) in "
+                f"criterion_order: {sorted(unknown)}. "
+                f"Valid names: {sorted(_VALID_CRITERION_NAMES)}"
+            )
+            raise ValueError(msg)
+
+    conv_criteria = opts.get("convergence_criteria")
+    if conv_criteria is not None:
+        if not isinstance(conv_criteria, dict):
+            msg = (
+                "convergence_criteria must be a dict mapping criterion names to bools."
+            )
+            raise TypeError(msg)
+        unknown = set(conv_criteria) - _VALID_CRITERION_NAMES
+        if unknown:
+            msg = (
+                "Unknown criterion name(s) in "
+                f"convergence_criteria: {sorted(unknown)}. "
+                f"Valid names: {sorted(_VALID_CRITERION_NAMES)}"
+            )
+            raise ValueError(msg)
+
+
 def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
     """Merge user kwargs with defaults using _options (case-insensitive).
 
@@ -1926,7 +1968,8 @@ def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
 
     Raises:
         ValueError: If ``compat_mode`` is not one of
-            ``{"strict_legacy", "modern"}``.
+            ``{"strict_legacy", "modern"}``, or if unknown criterion
+            names are supplied.
     """
     opts_default: dict[str, object] = {
         "init": "random",
@@ -1950,6 +1993,8 @@ def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
         "cfstop_curv": None,
         "composite_stop": None,
         "patience": 1,
+        "criterion_order": None,
+        "convergence_criteria": None,
         "verbose": 1,
         "num_cpu": None,
         "num_cpu_score_update": None,
@@ -1999,6 +2044,8 @@ def _build_options(kwargs: Mapping[str, object]) -> dict[str, object]:
     if ratio <= 0.0:
         ratio = 4.0
     opts["explained_var_gram_ratio"] = ratio
+
+    _validate_convergence_opts(opts)
 
     if wrnmsg:
         logger.warning("pca_full options warning: %s", wrnmsg)

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -36,6 +36,8 @@ class VBPCA:
         niter_broadprior: int | None = None,
         va_init: float | None = None,
         xprobe_fraction: float = 0.0,
+        criterion_order: list[str] | None = None,
+        convergence_criteria: dict[str, bool] | None = None,
         **opts: object,
     ) -> None:
         """
@@ -58,6 +60,12 @@ class VBPCA:
                 probe data (default 0.0, disabled).  When positive and no
                 explicit *xprobe* is passed to :meth:`fit`, a random probe
                 set is generated automatically.
+            criterion_order: Priority order for convergence criteria.
+                Defaults to ``DEFAULT_CRITERION_ORDER`` when ``None``.
+            convergence_criteria: Per-criterion enable/disable dict.  Keys
+                are criterion names, values are booleans.  Criteria set to
+                ``False`` are still evaluated for diagnostics but excluded
+                from the stop decision.  Defaults to all enabled.
             **opts: Additional options passed to the underlying PCA_FULL implementation.
         """
         self.n_components = n_components
@@ -71,6 +79,8 @@ class VBPCA:
         self.niter_broadprior = niter_broadprior
         self.va_init = va_init
         self.xprobe_fraction = xprobe_fraction
+        self.criterion_order = criterion_order
+        self.convergence_criteria = convergence_criteria
         self.opts = opts
         self.components_: np.ndarray | None = None
         self.scores_: np.ndarray | None = None
@@ -133,6 +143,10 @@ class VBPCA:
             opts["niter_broadprior"] = self.niter_broadprior
         if self.va_init is not None:
             opts["va_init"] = self.va_init
+        if self.criterion_order is not None:
+            opts["criterion_order"] = self.criterion_order
+        if self.convergence_criteria is not None:
+            opts["convergence_criteria"] = self.convergence_criteria
         opts.update(self.opts)
         if xprobe is not None:
             opts["xprobe"] = xprobe
@@ -283,6 +297,10 @@ class VBPCA:
             opts["niter_broadprior"] = self.niter_broadprior
         if self.va_init is not None:
             opts["va_init"] = self.va_init
+        if self.criterion_order is not None:
+            opts["criterion_order"] = self.criterion_order
+        if self.convergence_criteria is not None:
+            opts["convergence_criteria"] = self.convergence_criteria
         opts.update(self.opts)
         return _build_options(opts)
 

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from vbpca_py._converge import convergence_check
+from vbpca_py._converge import DEFAULT_CRITERION_ORDER, convergence_check
 
 
 def _lc(
@@ -800,3 +800,152 @@ def test_patience_1_is_default_behaviour() -> None:
 
     msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
     assert "angle" in msg.lower()
+
+
+# --------------------------------------------------------------------------
+# Criterion ordering (criterion_order)
+# --------------------------------------------------------------------------
+
+
+def test_default_criterion_order_matches_current_behaviour() -> None:
+    """DEFAULT_CRITERION_ORDER reproduces the existing hardcoded priority."""
+    assert DEFAULT_CRITERION_ORDER == [
+        "angle",
+        "earlystop",
+        "rms_plateau",
+        "cost",
+        "composite",
+        "slowing_down",
+    ]
+
+
+def test_criterion_order_changes_winner() -> None:
+    """Reordering criteria lets a lower-priority criterion win."""
+    # Both angle and rms_plateau would fire; default order → angle wins.
+    opts_default: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": [2, 1e-1, 1e-1],
+        "cfstop": None,
+    }
+    lc = _lc(rms=[1.0, 1.0, 1.0], prms=[1.0, 0.9, 0.8], cost=[10.0, 9.0, 8.0])
+
+    msg = convergence_check(opts_default, lc, angle_a=1e-4, sd_iter=None)
+    assert "angle" in msg.lower()
+
+    # Now put rms_plateau first.
+    opts_reordered = {
+        **opts_default,
+        "criterion_order": [
+            "rms_plateau",
+            "angle",
+            "earlystop",
+            "cost",
+            "composite",
+            "slowing_down",
+        ],
+    }
+    lc2 = _lc(rms=[1.0, 1.0, 1.0], prms=[1.0, 0.9, 0.8], cost=[10.0, 9.0, 8.0])
+    msg2 = convergence_check(opts_reordered, lc2, angle_a=1e-4, sd_iter=None)
+    assert "rms" in msg2.lower()
+
+
+def test_criterion_order_none_uses_default() -> None:
+    """criterion_order=None reproduces default order."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": None,
+        "cfstop": None,
+        "criterion_order": None,
+    }
+    lc = _lc(rms=[1.0, 0.9], prms=[1.0, 0.9], cost=[10.0, 9.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    assert "angle" in msg.lower()
+
+
+# --------------------------------------------------------------------------
+# Per-criterion enable/disable (convergence_criteria)
+# --------------------------------------------------------------------------
+
+
+def test_disabled_criterion_is_skipped() -> None:
+    """Disabling the angle criterion lets a lower one fire instead."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": [2, 1e-1, 1e-1],
+        "cfstop": None,
+        "convergence_criteria": {"angle": False},
+    }
+    lc = _lc(rms=[1.0, 1.0, 1.0], prms=[1.0, 0.9, 0.8], cost=[10.0, 9.0, 8.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    # angle is disabled, so rms_plateau should win.
+    assert "rms" in msg.lower()
+    assert "angle" not in msg.lower()
+
+
+def test_disabled_criterion_no_stop() -> None:
+    """Disabling the only triggering criterion results in no stop."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": None,
+        "cfstop": None,
+        "convergence_criteria": {"angle": False},
+    }
+    lc = _lc(rms=[1.0, 0.9], prms=[1.0, 0.9], cost=[10.0, 9.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    assert not msg
+
+
+def test_all_enabled_by_default() -> None:
+    """Empty convergence_criteria dict means all criteria are enabled."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": None,
+        "cfstop": None,
+        "convergence_criteria": {},
+    }
+    lc = _lc(rms=[1.0, 0.9], prms=[1.0, 0.9], cost=[10.0, 9.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    assert "angle" in msg.lower()
+
+
+def test_convergence_criteria_none_enables_all() -> None:
+    """convergence_criteria=None enables all criteria (default)."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": False,
+        "rmsstop": None,
+        "cfstop": None,
+        "convergence_criteria": None,
+    }
+    lc = _lc(rms=[1.0, 0.9], prms=[1.0, 0.9], cost=[10.0, 9.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    assert "angle" in msg.lower()
+
+
+def test_ordering_and_disable_combined() -> None:
+    """criterion_order + convergence_criteria work together."""
+    opts: dict[str, Any] = {
+        "minangle": 1e-3,
+        "earlystop": True,
+        "rmsstop": [2, 1e-1, 1e-1],
+        "cfstop": None,
+        # Put earlystop first, but disable it.
+        "criterion_order": [
+            "earlystop",
+            "rms_plateau",
+            "angle",
+            "cost",
+            "composite",
+            "slowing_down",
+        ],
+        "convergence_criteria": {"earlystop": False},
+    }
+    lc = _lc(rms=[1.0, 1.0, 1.0], prms=[0.5, 0.4, 0.45], cost=[10.0, 9.0, 8.0])
+    msg = convergence_check(opts, lc, angle_a=1e-4, sd_iter=None)
+    # earlystop is first but disabled; rms_plateau is next and fires.
+    assert "rms" in msg.lower()

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -355,3 +355,38 @@ def test_diagnostics_none_before_fit() -> None:
     assert model.n_iter_ is None
     assert model.convergence_reason_ is None
     assert model.learning_curve_ is None
+
+
+# --------------------------------------------------------------------------
+# criterion_order / convergence_criteria forwarding
+# --------------------------------------------------------------------------
+
+
+def test_criterion_order_forwarded_through_estimator() -> None:
+    """criterion_order kwarg reaches _build_options via VBPCA."""
+    order = ["cost", "angle", "rms_plateau", "earlystop", "composite", "slowing_down"]
+    model = VBPCA(n_components=2, criterion_order=order)
+    resolved = model.get_options()
+    assert resolved["criterion_order"] == order
+
+
+def test_convergence_criteria_forwarded_through_estimator() -> None:
+    """convergence_criteria kwarg reaches _build_options via VBPCA."""
+    crit = {"angle": False, "cost": True}
+    model = VBPCA(n_components=2, convergence_criteria=crit)
+    resolved = model.get_options()
+    assert resolved["convergence_criteria"] == crit
+
+
+def test_criterion_order_invalid_name_raises() -> None:
+    """Unknown criterion name in criterion_order raises ValueError."""
+    model = VBPCA(n_components=2, criterion_order=["angle", "bogus"])
+    with pytest.raises(ValueError, match="Unknown criterion name"):
+        model.get_options()
+
+
+def test_convergence_criteria_invalid_name_raises() -> None:
+    """Unknown criterion name in convergence_criteria raises ValueError."""
+    model = VBPCA(n_components=2, convergence_criteria={"bogus": True})
+    with pytest.raises(ValueError, match="Unknown criterion name"):
+        model.get_options()


### PR DESCRIPTION
This pull request introduces significant improvements to the convergence criteria system in the VBPCA implementation. It adds support for customizable priority ordering of convergence criteria and per-criterion enable/disable controls, making model convergence more flexible and user-configurable. These features are fully documented, validated, and tested throughout the codebase.

**Enhancements to convergence criteria configuration:**

* Added `criterion_order` option to allow users to specify the priority order in which convergence criteria are evaluated, instead of using a fixed order. (`src/vbpca_py/_converge.py`, `src/vbpca_py/estimators.py`, `src/vbpca_py/_pca_full.py`, [[1]](diffhunk://#diff-d3badb83c2d9f3880153fada1977b6934a7b2536057022381d02b01bfc33a4b8R27-R38) [[2]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R39-R40) [[3]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1925-R1962) [[4]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1996-R1997)
* Added `convergence_criteria` option to enable or disable individual convergence criteria without affecting their diagnostic evaluation. (`src/vbpca_py/_converge.py`, `src/vbpca_py/estimators.py`, `src/vbpca_py/_pca_full.py`, [[1]](diffhunk://#diff-d3badb83c2d9f3880153fada1977b6934a7b2536057022381d02b01bfc33a4b8L415-R434) [[2]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R39-R40) [[3]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1925-R1962) [[4]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1996-R1997)

**Validation and error handling:**

* Implemented validation in `_build_options` to check for unknown or incorrectly typed criterion names in both `criterion_order` and `convergence_criteria`, raising informative errors for invalid input. (`src/vbpca_py/_pca_full.py`, [[1]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1925-R1962) [[2]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aL1929-R1972)

**Estimator API and forwarding:**

* Updated the `VBPCA` estimator to accept and forward `criterion_order` and `convergence_criteria` through its API, ensuring these options are correctly passed to the underlying implementation. (`src/vbpca_py/estimators.py`, [[1]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R39-R40) [[2]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R63-R68) [[3]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R82-R83) [[4]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R146-R149) [[5]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R300-R303)

**Documentation and usage examples:**

* Expanded documentation with detailed explanations and practical examples for customizing convergence behavior using the new options. (`docs/concepts/convergence.md`, `docs/howto/convergence.md`, [[1]](diffhunk://#diff-1a37bc46aafa448b809448cf8918a0cc00e3d41f10615a15378d87d2bcf80571R89-R111) [[2]](diffhunk://#diff-80088afe00f413ca202bff432c09deef6da171c5b031f6a77ced6b6534217cd9R100-R146)

**Testing:**

* Added comprehensive tests to verify correct behavior of criterion ordering, per-criterion enable/disable, option forwarding, and validation of invalid input. (`tests/test_converge.py`, `tests/test_estimators.py`, [[1]](diffhunk://#diff-c08bc7071879e03f281dad82202a9e3c4d67734c5dd95d97101c308e3e81648fR803-R951) [[2]](diffhunk://#diff-6ca131fb42e4039c453957ed9cc67df43916e6bfba7ee6081b903ea33ad3d32bR358-R392)

Closes #101 