### PR TITLE
feat: add scikit-learn compatibility (#34)

### DIFF
--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -16,10 +16,12 @@ from vbpca_py._missing import make_xprobe_mask
 from vbpca_py._pca_full import Matrix, _build_options, pca_full
 from vbpca_py.model_selection import SelectionConfig, select_n_components
 
+from sklearn.base import BaseEstimator, TransformerMixin
+
 __all__ = ["VBPCA"]
 
 
-class VBPCA:
+class VBPCA(BaseEstimator, TransformerMixin):
     """Variational Bayesian PCA with a sklearn-like interface."""
 
     def __init__(  # noqa: PLR0913
@@ -101,6 +103,38 @@ class VBPCA:
         self._sv: list[np.ndarray] | None = None
         self._pattern_index: np.ndarray | None = None
         self._muv: np.ndarray | None = None
+
+    def get_params(self, deep: bool = True) -> dict[str, object]:
+        params = {
+            "n_components": self.n_components,
+            "bias": self.bias,
+            "maxiters": self.maxiters,
+            "tol": self.tol,
+            "verbose": self.verbose,
+            "hp_va": self.hp_va,
+            "hp_vb": self.hp_vb,
+            "hp_v": self.hp_v,
+            "niter_broadprior": self.niter_broadprior,
+            "va_init": self.va_init,
+            "xprobe_fraction": self.xprobe_fraction,
+            "criterion_order": self.criterion_order,
+            "convergence_criteria": self.convergence_criteria,
+        }
+        params.update(self.opts)
+        return params
+
+    def set_params(self, **params: object) -> VBPCA:
+        valid_params = {
+            "n_components", "bias", "maxiters", "tol", "verbose", "hp_va", 
+            "hp_vb", "hp_v", "niter_broadprior", "va_init", "xprobe_fraction", 
+            "criterion_order", "convergence_criteria"
+        }
+        for key, value in params.items():
+            if key in valid_params:
+                setattr(self, key, value)
+            else:
+                self.opts[key] = value
+        return self
 
     def fit(  # noqa: C901, PLR0912, PLR0914, PLR0915
         self,

--- a/src/vbpca_py/preprocessing.py
+++ b/src/vbpca_py/preprocessing.py
@@ -13,6 +13,8 @@ import scipy.sparse as sp
 
 from ._sparsity import validate_mask_compatibility
 
+from sklearn.base import BaseEstimator, TransformerMixin
+
 __all__ = [
     "AutoEncoder",
     "DataReport",
@@ -106,7 +108,7 @@ def _safe_unique(values: np.ndarray) -> list[Any]:
     return uniq
 
 
-class MissingAwareOneHotEncoder:
+class MissingAwareOneHotEncoder(BaseEstimator, TransformerMixin):
     """One-hot encode categorical columns while respecting missing values."""
 
     def __init__(
@@ -346,7 +348,7 @@ class MissingAwareOneHotEncoder:
                 col_vals[i] = cats[idx]
 
 
-class _BaseScaler:
+class _BaseScaler(BaseEstimator, TransformerMixin):
     def __init__(self) -> None:
         self.n_features_in_: int | None = None
 
@@ -369,7 +371,7 @@ class _BaseScaler:
         return self.fit(x, mask).transform(x, mask)
 
 
-class MissingAwareSparseOneHotEncoder:
+class MissingAwareSparseOneHotEncoder(BaseEstimator, TransformerMixin):
     """Sparse one-hot encoder for categorical columns.
 
     Assumptions:
@@ -717,7 +719,7 @@ class _ColumnPlan:
     slice_end: int
 
 
-class AutoEncoder:
+class AutoEncoder(BaseEstimator, TransformerMixin):
     """Column-wise router that applies missing-aware OHE or scaling."""
 
     def __init__(

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+from sklearn.pipeline import Pipeline
+from sklearn.base import clone
+
+from vbpca_py.estimators import VBPCA
+from vbpca_py.preprocessing import (
+    AutoEncoder,
+    MissingAwareStandardScaler,
+    MissingAwareMinMaxScaler,
+    MissingAwareOneHotEncoder,
+    MissingAwareSparseOneHotEncoder,
+)
+
+def test_sklearn_pipeline_roundtrip():
+    np.random.seed(42)
+    X = np.random.randn(10, 5)
+    
+    scaler = MissingAwareStandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    
+    pipe = Pipeline([
+        ("scaler", MissingAwareStandardScaler())
+    ])
+    pipe_scaled = pipe.fit_transform(X)
+    np.testing.assert_allclose(X_scaled, pipe_scaled)
+
+def test_sklearn_clone():
+    estimators = [
+        VBPCA(n_components=2, bias=False, maxiters=10),
+        MissingAwareStandardScaler(),
+        MissingAwareMinMaxScaler(),
+        MissingAwareOneHotEncoder(handle_unknown="ignore"),
+        MissingAwareSparseOneHotEncoder(),
+        AutoEncoder(cardinality_threshold=10)
+    ]
+    for est in estimators:
+        cloned = clone(est)
+        assert est.get_params() == cloned.get_params()


### PR DESCRIPTION
Fixes #34

Summary:
This PR enables full integration with the scikit-learn ecosystem by ensuring core estimators and preprocessing utilities inherit from `BaseEstimator` and `TransformerMixin`.

Changes:
- Added `BaseEstimator` and `TransformerMixin` inheritance to `VBPCA`, `AutoEncoder`, and all `MissingAware` scalers/encoders.
- Implemented custom `get_params` and `set_params` for `VBPCA` to support its variable keyword options.
- Added a new test suite `tests/test_sklearn_compat.py` covering `clone()` and `Pipeline` round-trips.
