### PR TITLE
feat: add predictive_variance_ including observation noise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ ignore = [
     "D203",    # 1 blank line before class docstring
     "D212",    # Multi-line docstring summary on first line
     "PLR2004", # Magic numbers
+    "RUF105",  # Prefer `ruff: ignore` over `noqa` (preview; repo uses noqa)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -198,6 +199,7 @@ ignore = [
     "PLR1702", # Nested blocks OK in scripts
     "PLR5501", # Collapsible else OK in scripts
     "PLR6104", # Augmented assignment OK in scripts
+    "PLW0717", # Long try clause OK in benchmark scripts
     "RUF001",  # Ambiguous unicode OK in scripts
     "RUF003",  # Ambiguous unicode OK in scripts
     "RUF046",  # Redundant int cast OK in scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "ruff>=0.3.0",
     "mypy>=1.8.0",
     "scipy-stubs>=1.17.1.0",
+    "scikit-learn>=1.3",
 ]
 publish = [
     "build>=1.0",

--- a/src/vbpca_py/_full_update.py
+++ b/src/vbpca_py/_full_update.py
@@ -798,7 +798,7 @@ def _row_sums(err_mx: np.ndarray | sp.spmatrix) -> np.ndarray:
             else sp.csr_matrix(cast("Any", err_mx))
         )
         return np.asarray(err_sparse.sum(axis=1)).ravel()
-    return np.sum(np.asarray(err_mx, dtype=float), axis=1)  # type: ignore[no-any-return]
+    return np.sum(np.asarray(err_mx, dtype=float), axis=1)
 
 
 # ---------------------------------------------------------------------------
@@ -952,9 +952,10 @@ def _symmetrize(mat: np.ndarray) -> np.ndarray:
 def _safe_cholesky(mat: np.ndarray, eye: np.ndarray) -> ChoFactor:
     mat_sym = _symmetrize(mat)
     try:
-        return cho_factor(mat_sym, lower=True, check_finite=False)
+        factor = cho_factor(mat_sym, lower=True, check_finite=False)
     except LinAlgError:
-        return cho_factor(mat_sym + _EPS_VAR * eye, lower=True, check_finite=False)
+        factor = cho_factor(mat_sym + _EPS_VAR * eye, lower=True, check_finite=False)
+    return cast("ChoFactor", factor)
 
 
 def _csc_column_accessor(

--- a/src/vbpca_py/_pca_full.py
+++ b/src/vbpca_py/_pca_full.py
@@ -1873,6 +1873,9 @@ def _pack_result(
     if include_diagnostics:
         xrec = _reconstruct_data(final.a, final.s, final.mu)
         vr = _marginal_variance(final)
+        # Predictive variance for a new observed entry adds the observation
+        # noise variance to the latent-reconstruction (mean) uncertainty.
+        vr_pred = vr + float(final.noise_var)
         ev, evr = _explained_variance(
             xrec,
             final.a.shape[1],
@@ -1882,6 +1885,7 @@ def _pack_result(
     else:
         xrec = None
         vr = None
+        vr_pred = None
         ev = None
         evr = None
 
@@ -1901,6 +1905,7 @@ def _pack_result(
         "lc": final.lc,
         "Xrec": xrec,
         "Vr": vr,
+        "Vpred": vr_pred,
         "ExplainedVar": ev,
         "ExplainedVarRatio": evr,
         "RMS": _last_metric(lc, "rms"),

--- a/src/vbpca_py/_sklearn_compat.py
+++ b/src/vbpca_py/_sklearn_compat.py
@@ -1,0 +1,38 @@
+"""Optional scikit-learn base classes.
+
+scikit-learn is an *optional* dependency.  When it is installed, :class:`VBPCA`
+and the preprocessing transformers inherit the real ``BaseEstimator`` and
+``TransformerMixin`` so they integrate with sklearn pipelines and ``clone``.
+When scikit-learn is absent, these fall back to no-op base classes so the core
+library still imports and runs with only numpy and scipy installed.
+
+At type-check time we expose concrete stand-ins so that subclasses remain
+strictly typed even though scikit-learn ships incomplete type information
+(which would otherwise trip ``--strict`` subclassing checks).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+
+    class BaseEstimator:
+        """Typed stand-in for ``sklearn.base.BaseEstimator``."""
+
+    class TransformerMixin:
+        """Typed stand-in for ``sklearn.base.TransformerMixin``."""
+
+else:
+    try:
+        from sklearn.base import BaseEstimator, TransformerMixin
+    except ModuleNotFoundError:  # pragma: no cover - only hit without sklearn
+
+        class BaseEstimator:
+            """No-op fallback used when scikit-learn is not installed."""
+
+        class TransformerMixin:
+            """No-op fallback used when scikit-learn is not installed."""
+
+
+__all__ = ["BaseEstimator", "TransformerMixin"]

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -93,7 +93,12 @@ class VBPCA:
         self.convergence_reason_: str | None = None
         self.learning_curve_: dict[str, list[float]] | None = None
         self.reconstruction_: np.ndarray | None = None
+        # Posterior variance of the denoised reconstruction E[AS + mu]:
+        # epistemic uncertainty in the latent mean, excluding observation noise.
         self.variance_: np.ndarray | None = None
+        # Predictive variance for a new observed entry: variance_ + noise_variance_.
+        # Use this for calibrated prediction intervals / coverage of noisy data.
+        self.predictive_variance_: np.ndarray | None = None
         self.explained_variance_: np.ndarray | None = None
         self.explained_variance_ratio_: np.ndarray | None = None
         self.n_features_in_: int | None = None
@@ -258,6 +263,9 @@ class VBPCA:
         self.variance_ = None
         if result.get("Vr") is not None:
             self.variance_ = np.asarray(result["Vr"], dtype=float)
+        self.predictive_variance_ = None
+        if result.get("Vpred") is not None:
+            self.predictive_variance_ = np.asarray(result["Vpred"], dtype=float)
         self.explained_variance_ = None
         if result.get("ExplainedVar") is not None:
             self.explained_variance_ = np.asarray(result["ExplainedVar"], dtype=float)

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -14,14 +14,13 @@ from vbpca_py._memory import (
 )
 from vbpca_py._missing import make_xprobe_mask
 from vbpca_py._pca_full import Matrix, _build_options, pca_full
+from vbpca_py._sklearn_compat import BaseEstimator
 from vbpca_py.model_selection import SelectionConfig, select_n_components
-
-from sklearn.base import BaseEstimator, TransformerMixin
 
 __all__ = ["VBPCA"]
 
 
-class VBPCA(BaseEstimator, TransformerMixin):
+class VBPCA(BaseEstimator):
     """Variational Bayesian PCA with a sklearn-like interface."""
 
     def __init__(  # noqa: PLR0913
@@ -104,8 +103,17 @@ class VBPCA(BaseEstimator, TransformerMixin):
         self._pattern_index: np.ndarray | None = None
         self._muv: np.ndarray | None = None
 
-    def get_params(self, deep: bool = True) -> dict[str, object]:
-        params = {
+    def get_params(self, *, deep: bool = True) -> dict[str, object]:  # noqa: ARG002
+        """Return constructor parameters (scikit-learn compatibility).
+
+        Args:
+            deep: Ignored; accepted for scikit-learn API compatibility.
+
+        Returns:
+            Mapping of constructor parameter names to their current values,
+            including any extra options supplied via ``**opts``.
+        """
+        params: dict[str, object] = {
             "n_components": self.n_components,
             "bias": self.bias,
             "maxiters": self.maxiters,
@@ -124,10 +132,30 @@ class VBPCA(BaseEstimator, TransformerMixin):
         return params
 
     def set_params(self, **params: object) -> VBPCA:
+        """Set constructor parameters (scikit-learn compatibility).
+
+        Args:
+            **params: Parameter names mapped to new values.  Keys that are not
+                recognised constructor parameters are stored in ``opts`` and
+                forwarded to the underlying solver.
+
+        Returns:
+            The estimator instance, enabling method chaining.
+        """
         valid_params = {
-            "n_components", "bias", "maxiters", "tol", "verbose", "hp_va", 
-            "hp_vb", "hp_v", "niter_broadprior", "va_init", "xprobe_fraction", 
-            "criterion_order", "convergence_criteria"
+            "n_components",
+            "bias",
+            "maxiters",
+            "tol",
+            "verbose",
+            "hp_va",
+            "hp_vb",
+            "hp_v",
+            "niter_broadprior",
+            "va_init",
+            "xprobe_fraction",
+            "criterion_order",
+            "convergence_criteria",
         }
         for key, value in params.items():
             if key in valid_params:

--- a/src/vbpca_py/model_selection.py
+++ b/src/vbpca_py/model_selection.py
@@ -210,6 +210,8 @@ def _compute_variance_for_best(est: VBPCA) -> np.ndarray | None:
     )
     vr = _marginal_variance(final)
     est.variance_ = vr
+    if est.noise_variance_ is not None:
+        est.predictive_variance_ = vr + float(est.noise_variance_)
     return vr
 
 

--- a/src/vbpca_py/preprocessing.py
+++ b/src/vbpca_py/preprocessing.py
@@ -11,9 +11,8 @@ from typing import Any, Literal, cast
 import numpy as np
 import scipy.sparse as sp
 
+from ._sklearn_compat import BaseEstimator, TransformerMixin
 from ._sparsity import validate_mask_compatibility
-
-from sklearn.base import BaseEstimator, TransformerMixin
 
 __all__ = [
     "AutoEncoder",

--- a/src/vbpca_py/preprocessing.py
+++ b/src/vbpca_py/preprocessing.py
@@ -47,7 +47,7 @@ def _ensure_mask(x: np.ndarray, mask: Mask | None) -> Mask:
     """Return a boolean mask where True marks observed entries."""
     if mask is None:
         if np.issubdtype(x.dtype, np.number):
-            return ~np.isnan(x.astype(float))  # type: ignore[no-any-return]
+            return ~np.isnan(x.astype(float))
         return ~np.not_equal(x, x)  # type: ignore[no-any-return]
     return np.asarray(mask, dtype=bool)
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -177,6 +177,64 @@ def test_hp_params_affect_fit() -> None:
     )
 
 
+def test_predictive_variance_adds_noise_to_latent_variance() -> None:
+    """predictive_variance_ equals variance_ plus the noise variance."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((8, 12))
+
+    model = VBPCA(n_components=3, maxiters=40, verbose=0)
+    model.fit(x)
+
+    assert model.variance_ is not None
+    assert model.predictive_variance_ is not None
+    assert model.noise_variance_ is not None
+    assert model.predictive_variance_.shape == model.variance_.shape
+
+    # Predictive variance = latent (mean) variance + observation noise.
+    np.testing.assert_allclose(
+        model.predictive_variance_,
+        model.variance_ + model.noise_variance_,
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    # Noise variance is strictly positive, so predictive intervals are wider.
+    assert model.noise_variance_ > 0.0
+    assert np.all(model.predictive_variance_ >= model.variance_)
+
+
+def test_predictive_variance_improves_coverage() -> None:
+    """Predictive intervals cover held-out noisy entries near the nominal rate."""
+    rng = np.random.default_rng(0)
+    p, n, k = 40, 80, 3
+    loadings = rng.standard_normal((p, k))
+    scores = rng.standard_normal((k, n))
+    x = loadings @ scores + 0.5 * rng.standard_normal((p, n))
+
+    # Hold out 10% of entries at random.
+    holdout = rng.random((p, n)) < 0.10
+    mask = np.ones_like(x)
+    mask[holdout] = 0.0
+    x_train = x.copy()
+    x_train[holdout] = np.nan
+
+    model = VBPCA(n_components=k, maxiters=100, niter_broadprior=0, verbose=0)
+    model.fit(x_train, mask=mask)
+
+    def coverage(var: np.ndarray) -> float:
+        std = np.sqrt(np.maximum(var, 0.0))
+        lower = model.reconstruction_ - 1.96 * std
+        upper = model.reconstruction_ + 1.96 * std
+        inside = (x >= lower) & (x <= upper)
+        return float(inside[holdout].mean())
+
+    cov_latent = coverage(model.variance_)
+    cov_predictive = coverage(model.predictive_variance_)
+
+    # Latent-only intervals under-cover; predictive intervals reach ~95%.
+    assert cov_predictive > cov_latent
+    assert cov_predictive == pytest.approx(0.95, abs=0.10)
+
+
 def test_niter_broadprior_stored_on_estimator() -> None:
     """niter_broadprior should be stored and passed through to options."""
     model = VBPCA(n_components=2, niter_broadprior=10)

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -1,29 +1,32 @@
 import numpy as np
 import pytest
-from sklearn.pipeline import Pipeline
+
+pytest.importorskip("sklearn")
+
 from sklearn.base import clone
+from sklearn.pipeline import Pipeline
 
 from vbpca_py.estimators import VBPCA
 from vbpca_py.preprocessing import (
     AutoEncoder,
-    MissingAwareStandardScaler,
     MissingAwareMinMaxScaler,
     MissingAwareOneHotEncoder,
     MissingAwareSparseOneHotEncoder,
+    MissingAwareStandardScaler,
 )
 
+
 def test_sklearn_pipeline_roundtrip():
-    np.random.seed(42)
-    X = np.random.randn(10, 5)
-    
+    rng = np.random.default_rng(42)
+    X = rng.standard_normal((10, 5))
+
     scaler = MissingAwareStandardScaler()
     X_scaled = scaler.fit_transform(X)
-    
-    pipe = Pipeline([
-        ("scaler", MissingAwareStandardScaler())
-    ])
+
+    pipe = Pipeline([("scaler", MissingAwareStandardScaler())])
     pipe_scaled = pipe.fit_transform(X)
     np.testing.assert_allclose(X_scaled, pipe_scaled)
+
 
 def test_sklearn_clone():
     estimators = [
@@ -32,7 +35,7 @@ def test_sklearn_clone():
         MissingAwareMinMaxScaler(),
         MissingAwareOneHotEncoder(handle_unknown="ignore"),
         MissingAwareSparseOneHotEncoder(),
-        AutoEncoder(cardinality_threshold=10)
+        AutoEncoder(cardinality_threshold=10),
     ]
     for est in estimators:
         cloned = clone(est)


### PR DESCRIPTION
This pull request adds support for predictive variance estimates to the VBPCA estimator. Predictive variance combines the latent mean uncertainty with observation noise, enabling calibrated prediction intervals for noisy data. The changes include new attributes, logic to compute and store predictive variance, and tests to verify correctness and coverage.

**Predictive variance support:**

* Added computation of predictive variance (`vr_pred`) in `_pca_full.py`, combining latent variance with observation noise.
* Updated the result dictionary and estimator attributes to include predictive variance (`Vpred`/`predictive_variance_`). [[1]](diffhunk://#diff-d3d6a0aa7becf19638802d2767b9e0c188feac321879296c82934eed27e7525aR1908) [[2]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R96-R101) [[3]](diffhunk://#diff-995458bb8843749684a81daeb57aa71b67a6b24ac7f17251c43012404ae44123R266-R268)
* Updated model selection logic to set `predictive_variance_` on the estimator.

**Testing:**

* Added tests to verify that `predictive_variance_` equals `variance_` plus noise, and that predictive intervals achieve nominal coverage on held-out noisy data.