### PR TITLE
fix: make scikit-learn an optional dependency (#103 follow-up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ ignore = [
     "D203",    # 1 blank line before class docstring
     "D212",    # Multi-line docstring summary on first line
     "PLR2004", # Magic numbers
+    "RUF105",  # Prefer `ruff: ignore` over `noqa` (preview; repo uses noqa)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -198,6 +199,7 @@ ignore = [
     "PLR1702", # Nested blocks OK in scripts
     "PLR5501", # Collapsible else OK in scripts
     "PLR6104", # Augmented assignment OK in scripts
+    "PLW0717", # Long try clause OK in benchmark scripts
     "RUF001",  # Ambiguous unicode OK in scripts
     "RUF003",  # Ambiguous unicode OK in scripts
     "RUF046",  # Redundant int cast OK in scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "ruff>=0.3.0",
     "mypy>=1.8.0",
     "scipy-stubs>=1.17.1.0",
+    "scikit-learn>=1.3",
 ]
 publish = [
     "build>=1.0",

--- a/src/vbpca_py/_full_update.py
+++ b/src/vbpca_py/_full_update.py
@@ -798,7 +798,7 @@ def _row_sums(err_mx: np.ndarray | sp.spmatrix) -> np.ndarray:
             else sp.csr_matrix(cast("Any", err_mx))
         )
         return np.asarray(err_sparse.sum(axis=1)).ravel()
-    return np.sum(np.asarray(err_mx, dtype=float), axis=1)  # type: ignore[no-any-return]
+    return np.sum(np.asarray(err_mx, dtype=float), axis=1)
 
 
 # ---------------------------------------------------------------------------
@@ -952,9 +952,10 @@ def _symmetrize(mat: np.ndarray) -> np.ndarray:
 def _safe_cholesky(mat: np.ndarray, eye: np.ndarray) -> ChoFactor:
     mat_sym = _symmetrize(mat)
     try:
-        return cho_factor(mat_sym, lower=True, check_finite=False)
+        factor = cho_factor(mat_sym, lower=True, check_finite=False)
     except LinAlgError:
-        return cho_factor(mat_sym + _EPS_VAR * eye, lower=True, check_finite=False)
+        factor = cho_factor(mat_sym + _EPS_VAR * eye, lower=True, check_finite=False)
+    return cast("ChoFactor", factor)
 
 
 def _csc_column_accessor(

--- a/src/vbpca_py/_sklearn_compat.py
+++ b/src/vbpca_py/_sklearn_compat.py
@@ -1,0 +1,38 @@
+"""Optional scikit-learn base classes.
+
+scikit-learn is an *optional* dependency.  When it is installed, :class:`VBPCA`
+and the preprocessing transformers inherit the real ``BaseEstimator`` and
+``TransformerMixin`` so they integrate with sklearn pipelines and ``clone``.
+When scikit-learn is absent, these fall back to no-op base classes so the core
+library still imports and runs with only numpy and scipy installed.
+
+At type-check time we expose concrete stand-ins so that subclasses remain
+strictly typed even though scikit-learn ships incomplete type information
+(which would otherwise trip ``--strict`` subclassing checks).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+
+    class BaseEstimator:
+        """Typed stand-in for ``sklearn.base.BaseEstimator``."""
+
+    class TransformerMixin:
+        """Typed stand-in for ``sklearn.base.TransformerMixin``."""
+
+else:
+    try:
+        from sklearn.base import BaseEstimator, TransformerMixin
+    except ModuleNotFoundError:  # pragma: no cover - only hit without sklearn
+
+        class BaseEstimator:
+            """No-op fallback used when scikit-learn is not installed."""
+
+        class TransformerMixin:
+            """No-op fallback used when scikit-learn is not installed."""
+
+
+__all__ = ["BaseEstimator", "TransformerMixin"]

--- a/src/vbpca_py/estimators.py
+++ b/src/vbpca_py/estimators.py
@@ -14,14 +14,13 @@ from vbpca_py._memory import (
 )
 from vbpca_py._missing import make_xprobe_mask
 from vbpca_py._pca_full import Matrix, _build_options, pca_full
+from vbpca_py._sklearn_compat import BaseEstimator
 from vbpca_py.model_selection import SelectionConfig, select_n_components
-
-from sklearn.base import BaseEstimator, TransformerMixin
 
 __all__ = ["VBPCA"]
 
 
-class VBPCA(BaseEstimator, TransformerMixin):
+class VBPCA(BaseEstimator):
     """Variational Bayesian PCA with a sklearn-like interface."""
 
     def __init__(  # noqa: PLR0913
@@ -104,8 +103,17 @@ class VBPCA(BaseEstimator, TransformerMixin):
         self._pattern_index: np.ndarray | None = None
         self._muv: np.ndarray | None = None
 
-    def get_params(self, deep: bool = True) -> dict[str, object]:
-        params = {
+    def get_params(self, *, deep: bool = True) -> dict[str, object]:  # noqa: ARG002
+        """Return constructor parameters (scikit-learn compatibility).
+
+        Args:
+            deep: Ignored; accepted for scikit-learn API compatibility.
+
+        Returns:
+            Mapping of constructor parameter names to their current values,
+            including any extra options supplied via ``**opts``.
+        """
+        params: dict[str, object] = {
             "n_components": self.n_components,
             "bias": self.bias,
             "maxiters": self.maxiters,
@@ -124,10 +132,30 @@ class VBPCA(BaseEstimator, TransformerMixin):
         return params
 
     def set_params(self, **params: object) -> VBPCA:
+        """Set constructor parameters (scikit-learn compatibility).
+
+        Args:
+            **params: Parameter names mapped to new values.  Keys that are not
+                recognised constructor parameters are stored in ``opts`` and
+                forwarded to the underlying solver.
+
+        Returns:
+            The estimator instance, enabling method chaining.
+        """
         valid_params = {
-            "n_components", "bias", "maxiters", "tol", "verbose", "hp_va", 
-            "hp_vb", "hp_v", "niter_broadprior", "va_init", "xprobe_fraction", 
-            "criterion_order", "convergence_criteria"
+            "n_components",
+            "bias",
+            "maxiters",
+            "tol",
+            "verbose",
+            "hp_va",
+            "hp_vb",
+            "hp_v",
+            "niter_broadprior",
+            "va_init",
+            "xprobe_fraction",
+            "criterion_order",
+            "convergence_criteria",
         }
         for key, value in params.items():
             if key in valid_params:

--- a/src/vbpca_py/preprocessing.py
+++ b/src/vbpca_py/preprocessing.py
@@ -11,9 +11,8 @@ from typing import Any, Literal, cast
 import numpy as np
 import scipy.sparse as sp
 
+from ._sklearn_compat import BaseEstimator, TransformerMixin
 from ._sparsity import validate_mask_compatibility
-
-from sklearn.base import BaseEstimator, TransformerMixin
 
 __all__ = [
     "AutoEncoder",

--- a/src/vbpca_py/preprocessing.py
+++ b/src/vbpca_py/preprocessing.py
@@ -47,7 +47,7 @@ def _ensure_mask(x: np.ndarray, mask: Mask | None) -> Mask:
     """Return a boolean mask where True marks observed entries."""
     if mask is None:
         if np.issubdtype(x.dtype, np.number):
-            return ~np.isnan(x.astype(float))  # type: ignore[no-any-return]
+            return ~np.isnan(x.astype(float))
         return ~np.not_equal(x, x)  # type: ignore[no-any-return]
     return np.asarray(mask, dtype=bool)
 

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -1,29 +1,32 @@
 import numpy as np
 import pytest
-from sklearn.pipeline import Pipeline
+
+pytest.importorskip("sklearn")
+
 from sklearn.base import clone
+from sklearn.pipeline import Pipeline
 
 from vbpca_py.estimators import VBPCA
 from vbpca_py.preprocessing import (
     AutoEncoder,
-    MissingAwareStandardScaler,
     MissingAwareMinMaxScaler,
     MissingAwareOneHotEncoder,
     MissingAwareSparseOneHotEncoder,
+    MissingAwareStandardScaler,
 )
 
+
 def test_sklearn_pipeline_roundtrip():
-    np.random.seed(42)
-    X = np.random.randn(10, 5)
-    
+    rng = np.random.default_rng(42)
+    X = rng.standard_normal((10, 5))
+
     scaler = MissingAwareStandardScaler()
     X_scaled = scaler.fit_transform(X)
-    
-    pipe = Pipeline([
-        ("scaler", MissingAwareStandardScaler())
-    ])
+
+    pipe = Pipeline([("scaler", MissingAwareStandardScaler())])
     pipe_scaled = pipe.fit_transform(X)
     np.testing.assert_allclose(X_scaled, pipe_scaled)
+
 
 def test_sklearn_clone():
     estimators = [
@@ -32,7 +35,7 @@ def test_sklearn_clone():
         MissingAwareMinMaxScaler(),
         MissingAwareOneHotEncoder(handle_unknown="ignore"),
         MissingAwareSparseOneHotEncoder(),
-        AutoEncoder(cardinality_threshold=10)
+        AutoEncoder(cardinality_threshold=10),
     ]
     for est in estimators:
         cloned = clone(est)


### PR DESCRIPTION
PR #103 imported sklearn.base at module level in estimators.py and preprocessing.py, making scikit-learn a hard import for the whole package though it is not a declared dependency. This broke CI (all test collection failed with ModuleNotFoundError) and any install without sklearn.

- Add _sklearn_compat with optional BaseEstimator/TransformerMixin (real when sklearn present, no-op fallback otherwise; TYPE_CHECKING stubs keep subclasses strictly typed).
- VBPCA now inherits only BaseEstimator: sklearn's TransformerMixin auto-wraps transform/fit_transform and clashed with VBPCA's native no-argument transform(), breaking fit_transform.
- Add scikit-learn to the dev extra so CI exercises the compat tests.
- Guard test_sklearn_compat with importorskip; fix lint/format (docstrings, keyword-only deep, legacy np.random, trailing ws).