### PR TITLE
feat: recommend_config + prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-17
+
+### Added
+- `recommend_config(n, p, missingness="auto", priority="balanced")`: regime-aware recommended `VBPCA` hyperparameters distilled from the Option A regime-surrogate trade study. The dominant lever is a strong ARD loadings prior (`hp_va` ~0.65-0.75 vs. the library default 0.001), which drives correct rank recovery — the default prior recovers the true rank only ~33% of the time. Exposed as `vbpca_py.recommend_config`.
+- `predictive_variance_` fitted attribute: reconstruction variance including observation noise (`variance_ + noise_variance_`). Prediction intervals built from `variance_` alone under-covered noisy held-out entries (~48-65% at nominal 95%); `predictive_variance_` restores coverage to ~94-96% (#104).
+- scikit-learn estimator compatibility for `VBPCA` (`get_params`/`set_params`, cloning) (#103, closes #34).
+- Configurable convergence-criterion ordering and per-criterion enable/disable via `criterion_order` and `convergence_criteria` constructor kwargs (#102, closes #101).
+- Convergence diagnostics exposed as fitted attributes: `n_iter_`, `convergence_reason_`, `learning_curve_` on `VBPCA`, plus per-trial `n_iter`/`convergence_reason` in `select_n_components` traces (#100, closes #99).
+- Public documentation site (MkDocs + GitHub Pages).
+
+### Changed
+- scikit-learn is now an optional dependency rather than a hard import (#105).
+
+### Fixed
+- mypy 2.3.0 strict-mode compatibility.
+
 ## [0.2.0] - 2026-04-15
 
 ### Added

--- a/justfile
+++ b/justfile
@@ -144,6 +144,10 @@ paper-figure-smoke:
 # ── Trade study (hyperparameter optimisation) ────────────────────
 # Requires: pip install -e "/path/to/trade-study[all]" in the venv.
 
+# Install local trade-study with adaptive extra (Optuna) into this venv.
+trade-a-install-adaptive:
+	uv pip install -p .venv/bin/python -e /home/jcmacdo/Documents/GitHub/jcm-sci/trade-study[adaptive]
+
 # Phase 1: Morris sensitivity screening (~5-15 min).
 trade-screen:
 	.venv/bin/python -m analysis.trade_study.phase1_screen
@@ -171,6 +175,66 @@ trade-plot fmt="png":
 # Re-run stability grid with default + optimized configs, then plot comparison.
 trade-compare fmt="png":
 	.venv/bin/python -m analysis.trade_study.compare --fmt {{fmt}}
+
+# ── Trade study: Option A (surrogate-first, rank_mae primary) ────
+
+# Collect surrogate-training data (Sobol design x regime grid, parallel).
+trade-a-collect n_samples="96":
+	.venv/bin/python -m analysis.trade_study.option_a_pipeline collect --n-samples {{n_samples}} --n-jobs -1
+
+# Fit the regime surrogate and recommend a config per regime.
+trade-a-recommend:
+	.venv/bin/python -m analysis.trade_study.option_a_pipeline recommend
+
+# Collect then recommend end-to-end.
+trade-a-all n_samples="96":
+	.venv/bin/python -m analysis.trade_study.option_a_pipeline all --n-samples {{n_samples}} --n-jobs -1
+
+# Generate the Option A figure suite (F1-F7).
+trade-a-figures fmt="png":
+	.venv/bin/python -m analysis.trade_study.option_a_figures --fmt {{fmt}}
+
+# Hyperparameter sensitivity report from the Option A surrogate-training table.
+trade-a-sensitivity fmt="png":
+	.venv/bin/python -m analysis.trade_study.sensitivity_report --fmt {{fmt}}
+
+# Sequential retuning: successive-halving + hyperband -> adaptive refinement (v4).
+trade-a-retune-seq n_samples="128" n_adaptive="200":
+	.venv/bin/python -m analysis.trade_study.v4_phase2_sequential --n-samples {{n_samples}} --n-adaptive {{n_adaptive}}
+
+# Fast smoke run of the v4 sequential retuning workflow.
+trade-a-retune-seq-smoke:
+	.venv/bin/python -m analysis.trade_study.v4_phase2_sequential --n-samples 16 --n-adaptive 24 --top-k 8 --rungs 10,20,40,80 --max-budget 80
+
+# Full v4 sequential retuning run tuned for the narrowed search workflow.
+trade-a-retune-seq-full n_samples="256" n_adaptive="400" top_k="48" max_budget="300" eta="3.0" rungs="25,50,100,200,300":
+	.venv/bin/python -m analysis.trade_study.v4_phase2_sequential --n-samples {{n_samples}} --n-adaptive {{n_adaptive}} --top-k {{top_k}} --max-budget {{max_budget}} --eta {{eta}} --rungs {{rungs}}
+
+# 3-way comparison: default vs rank_mae-recommended (surrogate) vs sklearn.
+# reps=3 is a fast validation; reps=10 (omit arg) is the full multi-hour grid.
+trade-a-compare reps="3" fmt="png":
+	.venv/bin/python -m analysis.trade_study.v3_compare --fmt {{fmt}} --reps {{reps}} --surrogate-config analysis/results/optionA/surrogate_train.json
+
+# Full 3-way comparison (reps=10, several hours).
+trade-a-compare-full fmt="png":
+	.venv/bin/python -m analysis.trade_study.v3_compare --fmt {{fmt}} --surrogate-config analysis/results/optionA/surrogate_train.json
+
+# Comprehensive parallel rank-selection benchmark (Option 3; SNR sweep, 8 comparators; multi-day).
+trade-a-benchmark reps="100":
+	.venv/bin/python -m analysis.trade_study.benchmark_full --reps {{reps}} --n-jobs -1
+
+# Analyze the comprehensive benchmark results.
+trade-a-benchmark-analyze:
+	.venv/bin/python -m analysis.trade_study.benchmark_full --analyze
+
+# Render comprehensive benchmark figures B1-B7 (works on partial results).
+trade-a-benchmark-figures fmt="png":
+	.venv/bin/python -m analysis.trade_study.benchmark_figures --fmt {{fmt}}
+
+# Run the convergence-trace study (quality vs iterations; feeds F1/F2).
+trade-a-convergence:
+	.venv/bin/python -m analysis.trade_study.convergence_trace --regime-set core --n-jobs -1
+
 
 # Build documentation site.
 docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vbpca_py"
-version = "0.2.0"
+version = "0.3.0"
 description = "Variational Bayesian PCA (Ilin & Raiko 2010) with support for missing data and missing entries."
 readme = "README.md"
 license = "MIT"

--- a/src/vbpca_py/__init__.py
+++ b/src/vbpca_py/__init__.py
@@ -3,6 +3,7 @@
 from importlib.metadata import version
 
 from vbpca_py._missing import make_xprobe_mask
+from vbpca_py.defaults import recommend_config
 from vbpca_py.estimators import VBPCA
 from vbpca_py.model_selection import (
     CVConfig,
@@ -39,6 +40,7 @@ __all__ = [
     "check_data",
     "cross_validate_components",
     "make_xprobe_mask",
+    "recommend_config",
     "select_n_components",
 ]
 

--- a/src/vbpca_py/defaults.py
+++ b/src/vbpca_py/defaults.py
@@ -1,0 +1,117 @@
+"""Regime-aware recommended configurations for VBPCA.
+
+:func:`recommend_config` returns :class:`~vbpca_py.estimators.VBPCA` keyword
+arguments tuned to maximise rank recovery (minimise ``rank_mae``) while keeping
+reconstruction error within a small tolerance of the library defaults.
+
+These configurations come from the Option A regime-surrogate trade study
+(``analysis/trade_study``).  The dominant lever is a **strong ARD loadings
+prior** (``hp_va`` ~ 0.7 versus the library default 0.001): it drives correct
+component pruning, whereas the weak default prior under-prunes and recovers the
+true rank only about a third of the time.  Recommendations are bucketed by the
+feature count ``p`` — the study's primary axis of rank-recovery difficulty.
+
+The returned dict is intended to be splatted into the estimator, e.g.::
+
+    from vbpca_py import VBPCA, recommend_config
+
+    cfg = recommend_config(n=200, p=100)
+    model = VBPCA(n_components=10, **cfg)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+__all__ = ["recommend_config"]
+
+Priority = Literal["balanced", "accuracy", "speed"]
+
+# Per-bucket baked recommendations (median of the surrogate's per-regime
+# rank_mae-optimal configs within each p-bucket).
+_BUCKET_CONFIGS: dict[str, dict[str, Any]] = {
+    "smallp": {
+        "hp_va": 0.70,
+        "hp_vb": 0.35,
+        "hp_v": 0.40,
+        "va_init": 5000.0,
+        "niter_broadprior": 0,
+        "maxiters": 300,
+        "xprobe_fraction": 0.01,
+    },
+    "trans": {
+        "hp_va": 0.75,
+        "hp_vb": 0.40,
+        "hp_v": 0.35,
+        "va_init": 5000.0,
+        "niter_broadprior": 50,
+        "maxiters": 300,
+        "xprobe_fraction": 0.01,
+    },
+    "large": {
+        "hp_va": 0.65,
+        "hp_vb": 0.55,
+        "hp_v": 0.20,
+        "va_init": 2500.0,
+        "niter_broadprior": 50,
+        "maxiters": 400,
+        "xprobe_fraction": 0.02,
+    },
+}
+
+_SMALLP_MAX_P = 30
+_TRANS_MAX_P = 70
+
+
+def _bucket(p: int) -> str:
+    """Return the feature-count bucket for ``p`` features."""
+    if p <= _SMALLP_MAX_P:
+        return "smallp"
+    if p <= _TRANS_MAX_P:
+        return "trans"
+    return "large"
+
+
+def recommend_config(
+    n: int,
+    p: int,
+    *,
+    missingness: str = "auto",  # noqa: ARG001 - reserved for future tuning
+    priority: Priority = "balanced",
+) -> dict[str, Any]:
+    """Recommend VBPCA keyword arguments for a data regime.
+
+    Args:
+        n: Number of samples (columns of the ``p x n`` data matrix).
+        p: Number of features (rows).  Selects the recommendation bucket.
+        missingness: Missingness descriptor.  Reserved for future
+            regime-specific tuning; accepted but not yet branched on.
+        priority: Trade-off preset.  ``"balanced"`` (default) uses the
+            tuned configuration as-is; ``"accuracy"`` raises the iteration
+            budget; ``"speed"`` lowers it and disables the broad-prior
+            warm-up.
+
+    Returns:
+        A dict of keyword arguments suitable for
+        ``VBPCA(n_components=..., **cfg)`` or ``select_n_components``.
+
+    Raises:
+        ValueError: If ``n`` or ``p`` is not positive, or if ``priority``
+            is not a recognised preset.
+    """
+    if n <= 0 or p <= 0:
+        msg = f"n and p must be positive; got n={n}, p={p}"
+        raise ValueError(msg)
+    if priority not in {"balanced", "accuracy", "speed"}:
+        msg = f"unknown priority {priority!r}"
+        raise ValueError(msg)
+
+    cfg = dict(_BUCKET_CONFIGS[_bucket(p)])
+
+    if priority == "speed":
+        cfg["maxiters"] = 100
+        cfg["niter_broadprior"] = 0
+    elif priority == "accuracy":
+        cfg["maxiters"] = int(cfg["maxiters"]) * 2
+
+    return cfg

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,53 @@
+"""Tests for regime-aware default configuration recommendations."""
+
+import numpy as np
+import pytest
+
+from vbpca_py import VBPCA, recommend_config
+
+
+def test_recommend_config_buckets_by_p() -> None:
+    """Different feature counts map to distinct recommendation buckets."""
+    small = recommend_config(n=100, p=20)
+    trans = recommend_config(n=100, p=50)
+    large = recommend_config(n=200, p=150)
+
+    # All expose the dominant ARD lever with a strong loadings prior.
+    for cfg in (small, trans, large):
+        assert cfg["hp_va"] >= 0.5
+
+    # Buckets are not all identical (p drives the recommendation).
+    assert not (small == trans == large)
+
+
+def test_recommend_config_priority_presets() -> None:
+    """Priority presets adjust the iteration budget as documented."""
+    balanced = recommend_config(n=100, p=100, priority="balanced")
+    speed = recommend_config(n=100, p=100, priority="speed")
+    accuracy = recommend_config(n=100, p=100, priority="accuracy")
+
+    assert speed["maxiters"] < balanced["maxiters"]
+    assert accuracy["maxiters"] > balanced["maxiters"]
+    assert speed["niter_broadprior"] == 0
+
+
+def test_recommend_config_validates_inputs() -> None:
+    """Non-positive sizes and unknown priorities raise ValueError."""
+    with pytest.raises(ValueError, match="must be positive"):
+        recommend_config(n=0, p=10)
+    with pytest.raises(ValueError, match="unknown priority"):
+        recommend_config(n=10, p=10, priority="fast")  # type: ignore[arg-type]
+
+
+def test_recommended_config_fits() -> None:
+    """A recommended config is accepted by the estimator and fits."""
+    rng = np.random.default_rng(0)
+    p, n, k = 50, 100, 5
+    x = rng.standard_normal((p, k)) @ rng.standard_normal((k, n))
+    x += 0.3 * rng.standard_normal((p, n))
+
+    cfg = recommend_config(n=n, p=p)
+    model = VBPCA(n_components=k, verbose=0, **cfg)
+    model.fit(x)
+    assert model.components_ is not None
+    assert model.components_.shape == (p, k)


### PR DESCRIPTION
## Summary
- `feat: add recommend_config regime-aware default hyperparameters` — ships the Option A regime-surrogate trade study's output (`analysis/trade_study`) as a public API. `recommend_config(n, p, priority)` returns `VBPCA` kwargs bucketed by feature count, using a strong ARD prior (`hp_va` ~0.65-0.75) that fixes the default's ~33% true-rank-recovery rate.
- `chore(release): prepare v0.3.0` — CHANGELOG entry covering everything merged since v0.2.0 (`predictive_variance_`, sklearn estimator compatibility as an optional dependency, configurable convergence-criterion ordering, convergence diagnostics, the new `recommend_config`, and the live docs site), plus the version bump.

## Test plan
- [x] `ruff format --check` / `ruff check` on `src tests scripts` — clean (pre-existing unformatted files live only in the untracked `analysis/` scratch directory, out of scope for this PR)
- [x] `mypy --strict src` — clean
- [x] `pytest --cov` — 470 passed, 90.14% coverage (≥89% gate); `defaults.py` at 100%
- [x] `just build-check` (sdist + wheel + twine check) — passed
- [x] `just build-test` (clean-room install + test) — 448 passed, 1 skipped (sklearn optional-dependency skip, as intended)

Merging this and tagging `v0.3.0` will trigger `publish.yml` to build and publish to PyPI on GitHub Release creation.