### PR TITLE
docs: sync citation/README with v0.3.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,8 +32,8 @@ keywords:
   - variational inference
   - machine learning
 license: MIT
-version: "0.2.0"
-date-released: "2026-04-02"
+version: "0.3.0"
+date-released: "2026-08-17"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.19389250"

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ More examples: [quickstart](https://yoavram-lab.github.io/VBPCApy/getting-starte
 - C++ extensions with runtime autotune for threading and memory
 - Missing-aware preprocessing: one-hot, standard/minmax scaling, log, power, winsorize, auto-routing (`AutoEncoder`)
 - Preflight data diagnostics via `check_data()` / `DataReport`
-- scikit-learn-compatible estimator (`fit`/`transform`/`inverse_transform`)
+- scikit-learn-compatible estimator (`fit`/`transform`/`inverse_transform`, `get_params`/`set_params`, cloning) — scikit-learn is an optional dependency
 - Model selection via `select_n_components` and `cross_validate_components`
-- Configurable convergence: subspace angle, RMS/cost plateau, ELBO, curvature, composite rules, patience
+- Configurable convergence: subspace angle, RMS/cost plateau, ELBO, curvature, composite rules, patience, with per-criterion enable/disable and custom ordering
+- Convergence diagnostics (`n_iter_`, `convergence_reason_`, `learning_curve_`) and calibrated `predictive_variance_` (includes observation noise)
+- `recommend_config(n, p, priority)` — regime-aware default hyperparameters from a surrogate trade study
 
 See the [concept guides](https://yoavram-lab.github.io/VBPCApy/concepts/algorithm/) and [API reference](https://yoavram-lab.github.io/VBPCApy/api/vbpca/) for full details.
 
@@ -82,7 +84,7 @@ If you use this package in your research, please cite:
   title = {{VBPCApy}: Variational Bayesian PCA with Missing Data Support},
   year = {2026},
   url = {https://github.com/yoavram-lab/VBPCApy},
-  version = {0.2.0},
+  version = {0.3.0},
 }
 ```
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -10,7 +10,7 @@ If you use this package in your research, please cite:
   title = {{VBPCApy}: Variational Bayesian PCA with Missing Data Support},
   year = {2026},
   url = {https://github.com/yoavram-lab/VBPCApy},
-  version = {0.2.0},
+  version = {0.3.0},
 }
 ```
 


### PR DESCRIPTION
## Summary
- `CITATION.cff` / `docs/citation.md` / README bibtex still referenced v0.2.0 (2026-04-02) after the v0.3.0 release — bumped version and date-released.
- README feature list didn't mention `predictive_variance_`, scikit-learn estimator compatibility, convergence diagnostics, or `recommend_config`, all shipped in v0.3.0.
- Verified the DOI badge (`10.5281/zenodo.19389250`) is the Zenodo **concept DOI**, which auto-resolves to the latest archived version (currently v0.3.0 → `10.5281/zenodo.21979869`) — confirmed via the Zenodo API, no change needed there.

## Test plan
- [x] `just docs` (`mkdocs build --strict`) — builds clean