### PR TITLE
fix: warn instead of silently ignoring missingness in recommend_config (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Behavior change:** the default (`random_state=None`) now draws fresh entropy on every `fit()` call. Previously, default initialization was silently seeded with a fixed value regardless of configuration, so repeated fits produced identical results without any way to request a different draw. Pass `random_state=<int>` for reproducible runs (#109).
+- `recommend_config()`'s `missingness` parameter now warns (`UserWarning`) when passed anything other than the default `"auto"`, instead of silently ignoring it. Recommendations are still bucketed by `p` only — the Option A trade study's example recommendations are too sparse per (p-bucket, missingness) cell (23 points across 3 p-buckets x 4 missingness categories) to bucket on responsibly without shipping unreplicated values (#110, see also #111).
 
 ## [0.3.0] - 2026-08-17
 

--- a/src/vbpca_py/defaults.py
+++ b/src/vbpca_py/defaults.py
@@ -21,6 +21,7 @@ The returned dict is intended to be splatted into the estimator, e.g.::
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Literal
 
 __all__ = ["recommend_config"]
@@ -76,7 +77,7 @@ def recommend_config(
     n: int,
     p: int,
     *,
-    missingness: str = "auto",  # noqa: ARG001 - reserved for future tuning
+    missingness: str = "auto",
     priority: Priority = "balanced",
 ) -> dict[str, Any]:
     """Recommend VBPCA keyword arguments for a data regime.
@@ -84,8 +85,17 @@ def recommend_config(
     Args:
         n: Number of samples (columns of the ``p x n`` data matrix).
         p: Number of features (rows).  Selects the recommendation bucket.
-        missingness: Missingness descriptor.  Reserved for future
-            regime-specific tuning; accepted but not yet branched on.
+        missingness: Missingness descriptor. **Not currently branched on** —
+            recommendations are bucketed by ``p`` only. The Option A trade
+            study evaluates missingness as a regime feature, but its example
+            recommendations span only 4 missingness categories x 3 p-buckets
+            from 23 design points total (some cells have a single point), too
+            sparse to bucket on without shipping unreplicated, effectively
+            arbitrary per-cell values (see #111). Passing anything other than
+            the default ``"auto"`` raises a :class:`UserWarning` rather than
+            silently doing nothing. Tracked in #110, blocked on trade-study
+            replication support (`jcm-sci/trade-study#112
+            <https://github.com/jcm-sci/trade-study/issues/112>`_).
         priority: Trade-off preset.  ``"balanced"`` (default) uses the
             tuned configuration as-is; ``"accuracy"`` raises the iteration
             budget; ``"speed"`` lowers it and disables the broad-prior
@@ -105,6 +115,15 @@ def recommend_config(
     if priority not in {"balanced", "accuracy", "speed"}:
         msg = f"unknown priority {priority!r}"
         raise ValueError(msg)
+    if missingness != "auto":
+        warnings.warn(
+            f"recommend_config() does not yet branch on missingness "
+            f"(got missingness={missingness!r}); recommendations are "
+            f"bucketed by p only. See "
+            f"https://github.com/yoavram-lab/VBPCApy/issues/110.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     cfg = dict(_BUCKET_CONFIGS[_bucket(p)])
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,5 +1,7 @@
 """Tests for regime-aware default configuration recommendations."""
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -37,6 +39,19 @@ def test_recommend_config_validates_inputs() -> None:
         recommend_config(n=0, p=10)
     with pytest.raises(ValueError, match="unknown priority"):
         recommend_config(n=10, p=10, priority="fast")  # type: ignore[arg-type]
+
+
+def test_recommend_config_default_missingness_does_not_warn() -> None:
+    """The default missingness="auto" is a documented no-op and stays silent."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        recommend_config(n=100, p=20)
+
+
+def test_recommend_config_explicit_missingness_warns() -> None:
+    """Passing a non-default missingness warns that it is not yet branched on."""
+    with pytest.warns(UserWarning, match="does not yet branch on missingness"):
+        recommend_config(n=100, p=20, missingness="mcar")
 
 
 def test_recommended_config_fits() -> None:


### PR DESCRIPTION
## Summary

`recommend_config()` accepted a `missingness` kwarg that was silently discarded (`# noqa: ARG001 - reserved for future tuning`). Per #110, resolved via the issue's option (2): document why it isn't branched on yet and make the no-op explicit, rather than fabricate a missingness-conditional bucketing.

## Why not branch on it (option 1)?

The Option A trade study's exported example recommendations (`analysis/results/optionA/recommendations.json`) span only 23 design points across 3 p-buckets x 4 missingness categories — several (p-bucket, missingness) cells have exactly one point. Bucketing on that would ship single-draw, unreplicated numbers per cell, which is precisely the problem #111 already flags for the existing p-only bucketing (no replication anywhere in the pipeline; sensitivity data doesn't clearly support the shipped `hp_va` framing). Doing it properly requires trade-study support for replicated trials (`jcm-sci/trade-study#112`, still open) before any new baked-in per-cell values could be trusted.

## Change

- `recommend_config(missingness=...)`: passing anything other than the default `"auto"` now raises a `UserWarning` pointing at #110, instead of accepting and ignoring the value.
- Docstring rewritten to explain the sparsity reasoning and link forward to #111 and trade-study#112.
- Tests: default `"auto"` stays silent (asserted via `warnings.simplefilter("error")`); non-default value warns with the expected message.
- CHANGELOG `Unreleased` entry.

Closes #110

## Test plan
- [x] `just ci` green locally: 481 passed, 90.21% coverage (gate 89%)