### PR TITLE
fix: F1/F2 skip gracefully instead of crashing the whole Option A figure suite

### DIFF
--- a/analysis/trade_study/option_a_figures.py
+++ b/analysis/trade_study/option_a_figures.py
@@ -35,10 +35,20 @@ _BUCKET_ORDER = ["smallp", "trans", "large"]
 _BUCKET_COLOR = {"smallp": "#1f77b4", "trans": "#ff7f0e", "large": "#2ca02c"}
 
 
-def _load_trace() -> list[dict[str, Any]]:
+def _load_trace() -> list[dict[str, Any]] | None:
+    """Load convergence-trace rows, or None if that data isn't present.
+
+    The convergence-characterization paper (and the script that produced
+    this data) moved to its own repo, jcm-sci/vbpca-convergence -- F1/F2
+    skip rather than crash the whole figure suite when it's absent from
+    this one.
+    """
     if not TRACE.exists():
-        msg = f"convergence-trace data missing: {TRACE}"
-        raise SystemExit(msg)
+        print(
+            f"  skipping -- convergence-trace data lives in "
+            f"jcm-sci/vbpca-convergence now, not found at {TRACE}"
+        )
+        return None
     return [
         {k: v for k, v in row.items() if k != "lc"}
         for row in json.loads(TRACE.read_text())
@@ -63,6 +73,8 @@ def fig_f1_knee(fmt: str) -> None:
     import matplotlib.pyplot as plt
 
     rows = _load_trace()
+    if rows is None:
+        return
     metrics = [
         ("holdout_rmse", "Holdout RMSE", False),
         ("holdout_mae", "Holdout MAE", False),
@@ -102,6 +114,8 @@ def fig_f2_broadprior(fmt: str) -> None:
     import matplotlib.pyplot as plt
 
     rows = _load_trace()
+    if rows is None:
+        return
     bps = sorted({r["niter_broadprior"] for r in rows})
     fig, (ax_q, ax_i) = plt.subplots(1, 2, figsize=(11, 4.2))
 


### PR DESCRIPTION
## Summary

`option_a_figures.py`'s own documented usage (`--fmt png`, no args) has been silently broken since the Aug 17 prune commit that removed `convergence_trace.py` (moved to jcm-sci/vbpca-convergence). F1/F2 hard-depend on `results/convergence_trace/sweep.json`; `_load_trace()` raised `SystemExit` when it's missing, which killed `main()`'s figure loop before F3/F5/F7 ever ran. Every PNG checked into `analysis/results/figures/optionA/` predates the prune and hasn't regenerated since.

## Change

`_load_trace()` returns `None` (with a one-line console notice) instead of raising when the trace file is absent; `fig_f1_knee`/`fig_f2_broadprior` skip early on `None`. `--only f3 f5 f7` already worked around this; now the full default invocation does too.

## Verification

```
$ python -m analysis.trade_study.option_a_figures --fmt png
Generating F1 ...
  skipping -- convergence-trace data lives in jcm-sci/vbpca-convergence now, not found at analysis/results/convergence_trace/sweep.json
Generating F2 ...
  skipping -- ...
Generating F3 ...
  saved analysis/results/figures/optionA/figure_f3_coverage.png
Generating F5 ...
  saved analysis/results/figures/optionA/figure_f5_pareto.png
Generating F7 ...
  saved analysis/results/figures/optionA/figure_f7_regime_map.png
$ echo $?
0
```

F7 (recommended-config `rank_mae` over the `(n, p)` plane) is worth a look while reviewing -- it visually shows the RegimeSurrogate never trained on anything past `p<=n`-ish, corroborating #116's finding independently.

## Test plan
- [x] `just ci` passes (this script isn't covered by `mypy`/pytest coverage gates, which only scope `src/`)
- [x] Manual run above, both with and without `results/convergence_trace/` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)